### PR TITLE
Allow the specification of a constrained version

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -51,3 +51,6 @@ suites:
     run_list:
       - recipe[test::direct_url]
     includes: centos-6.9
+  - name: constrained
+    run_list:
+      - recipe[test::constrained]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Installs the mixlib-install/mixlib-install gems and upgrades the chef-client.
 
 - `channel` - The chef channel you fetch the chef client from. `stable` contains all officially released chef-client builds where as `current` contains unreleased builds. Default: `stable`
 - `prevent_downgrade` - Don't allow this cookbook to downgrade the chef-client version. Default: true
-- `version` - The version of the chef-client to install. Default :latest
+- `version` - The version of the chef-client to install. It is possible to use standard version constraints, eg. '~> 13.0' Default :latest
 - `post_install_action` - After installing the chef-client what should we do. `exec` to exec the new client or `kill` to kill the client and rely on the init system to start up the new version. Default: `exec`
 - `exec_command` - The chef-client command. default: $PROGRAM_NAME.split(' ').first
 - `exec_args` - An array of arguments to exec the chef-client with. default: ARGV

--- a/test/cookbooks/test/recipes/constrained.rb
+++ b/test/cookbooks/test/recipes/constrained.rb
@@ -1,0 +1,3 @@
+chef_client_updater 'Install constrained version' do
+  version '~> 13.0'
+end


### PR DESCRIPTION
### Description

This allows the option of specifying a constrained version using the [standard constraint syntax](https://docs.chef.io/cookbook_versions.html).

### Issues Resolved

#7 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
