### PR TITLE
Support for Windows

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -138,7 +138,7 @@ def run_post_install_action
     Chef::Log.warn 'Replacing ourselves with the new version of Chef to continue the run.'
     Kernel.exec(new_resource.exec_command, *new_resource.exec_args)
   when 'kill'
-    if Chef::Config[:client_fork] && Process.ppid != 1
+    if Chef::Config[:client_fork] && Process.ppid != 1 && !windows?
       Chef::Log.warn 'Chef client is defined for forked runs. Sending TERM to parent process!'
       Process.kill('TERM', Process.ppid)
     end
@@ -191,7 +191,7 @@ def execute_install_script(install_script)
       code <<-EOH
     #{install_script}
       EOH
-    end
+    end.run_action(:run)
   else
     upgrade_command = Mixlib::ShellOut.new(install_script)
     upgrade_command.run_command


### PR DESCRIPTION
There were several problems that blocked this from working on Windows.

First, since platform and architecture weren't being supplied to mixlib-install, it was trying to run the bash script to install Chef.  That no work.

Second, after changing it to make mixlib-install generate the powershell scripts, the command was too long for mixlib-shellout to execute.

Third, most of the operations were in ruby, so they were happening at compile time inside the resource. The execute block to move the directories never got called because Process.exit was happening first.

Making the execute block that moved directories happen earlier required moving the generation of the mixlib-install script before that, as the attempt to `require` mixlib-install would fail if the move happened first.

Yay for ordering...


