### PR TITLE
lower testing to chef-11.10.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
       sudo: required
       before_script:
         - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
-      # 11.10.4 is the earliest we can test due to test-kitchen / chef-zero not supporting earlier
+      # 11.8.2 is the earliest we can test due to test-kitchen / chef-zero not supporting earlier
       # (cookbook likely supports earlier versions)
       env:
         - OMNIBUS_CHEF_VERSION=11.8.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,10 @@ matrix:
       sudo: required
       before_script:
         - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
-      # 11.8.2 is the earliest we can test due to test-kitchen / chef-zero not supporting earlier
+      # 11.10.4 is the earliest we can test due to test-kitchen / chef-zero not supporting earlier
       # (cookbook likely supports earlier versions)
       env:
-        - OMNIBUS_CHEF_VERSION=11.8.2
+        - OMNIBUS_CHEF_VERSION=11.10.4
         - KITCHEN_YAML=.kitchen.dokken.yml
       script:
         - bundle exec kitchen test default-ubuntu-1604

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
       # 11.10.4 is the earliest we can test due to test-kitchen / chef-zero not supporting earlier
       # (cookbook likely supports earlier versions)
       env:
-        - OMNIBUS_CHEF_VERSION=11.18.12
+        - OMNIBUS_CHEF_VERSION=11.8.2
         - KITCHEN_YAML=.kitchen.dokken.yml
       script:
         - bundle exec kitchen test default-ubuntu-1604

--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ This cookbook updates the chef-client
 
 - Chef 11.6.2+
 
-### Cookbooks
-
-- <none>
-
 ## Usage
 
 This cookbook provides both a custom resource and a default recipe. The default recipe simply uses the custom resource with a set of attributes. You can add chef_client_updater::default to your run list or use the custom resource in a wrapper cookbook.


### PR DESCRIPTION
lowest version that chef_zero provisioner of test-kitchen works
with (and likely that kitchen-dokken works with)

