### PR TITLE
add run_action :nothing

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -191,6 +191,7 @@ def execute_install_script(install_script)
       code <<-EOH
     #{install_script}
       EOH
+      action :nothing
     end.run_action(:run)
   else
     upgrade_command = Mixlib::ShellOut.new(install_script)


### PR DESCRIPTION
when forcing to run at compile time we should always no-op the
running at converge time.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>
