### PR TITLE
Make  chef_client_updater work again in air-gapped environments

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -103,7 +103,13 @@ def update_necessary?
   load_mixlib_versioning
   cur_version = Mixlib::Versioning.parse(current_version)
   # we have to "resolve" partial versions like "12" through mixlib-install before comparing them here
-  des_version = Mixlib::Versioning.parse(mixlib_install.artifact_info.version)
+  des_version =
+    if new_resource.download_url_override
+      # probably in an air-gapped environment.
+      Mixlib::Versioning.parse(desired_version)
+    else
+      Mixlib::Versioning.parse(mixlib_install.artifact_info.version)
+    end
   Chef::Log.debug("The current chef-client version is #{cur_version} and the desired version is #{desired_version}")
   new_resource.prevent_downgrade ? (des_version > cur_version) : (des_version != cur_version)
 end


### PR DESCRIPTION
### Description

Make  chef_client_updater work again in air-gapped environments

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
