### PR TITLE
Fix #31 detect centos platform correctly

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -70,12 +70,13 @@ end
 
 def mixlib_install
   load_mixlib_install
+  detected_platform = Mixlib::Install.detect_platform
   options = {
     product_name: 'chef',
     platform_version_compatibility_mode: true,
-    platform: node['platform'],
-    platform_version: node['platform_version'],
-    architecture: node['kernel']['machine'],
+    platform: detected_platform[:platform],
+    platform_version: detected_platform[:platform_version],
+    architecture: detected_platform[:architecture],
     channel: new_resource.channel.to_sym,
     product_version: new_resource.version == 'latest' ? :latest : new_resource.version,
   }


### PR DESCRIPTION
- uses code adapted from chef-ingredient cookbook

Signed-off-by: Doc Walker <4-20ma@wvfans.net>

### Description

Fixes platform detection for `centos`

### Issues Resolved

#31 

### Check List

- [x]* All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [N/A] New functionality includes testing.
- [N/A] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

* Syntax check fails due to existing issue unrelated to this PR:

```
FC023: Prefer conditional attributes: ./providers/default.rb:229
Phase failed with exit code (3)!
```
