### PR TITLE
change prevent_downgrade attribute to false to match resource+docs

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook::  chef_client_updater
 # Attributes:: default
 #
-# Copyright:: 2016-2017, Chef Software, Inc.
+# Copyright:: 2016-2017, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 default['chef_client_updater']['channel'] = 'stable'
 
 # prevent a newer client "updating" to an older client
-default['chef_client_updater']['prevent_downgrade'] = true
+default['chef_client_updater']['prevent_downgrade'] = false
 
 # the version to install (ex: '12.12.13') or 'latest'
 default['chef_client_updater']['version'] = 'latest'


### PR DESCRIPTION
the attribute and the resource defaults disagree and that is confusing
and needs to be fixed.

this is the correct setting for configuration management.  to do config
management correctly you should be expressing your requirements as
equality pins.  if you have a later version installed you actually do
want to downgrade it.

otherwise you will not have consistent bugs across your production
environment, and your testing on any given version will be invalid.

to allow later versions on your systems means you are trusting that
i never write code which introduces bugs -- thank you for the vote of
confidence, but you're so very, very wrong.

this change will change behavior for some users.  perhaps surprsingly,
so we might already need to do a major bump to 3.0.0 here.

closes #44 