### PR TITLE
change default to 'kill' from 'exec'

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Installs the mixlib-install/mixlib-install gems and upgrades the chef-client.
 - `channel` - The chef channel you fetch the chef client from. `stable` contains all officially released chef-client builds where as `current` contains unreleased builds. Default: `stable`
 - `prevent_downgrade` - Don't allow this cookbook to downgrade the chef-client version. Default: false
 - `version` - The version of the chef-client to install. Default :latest
-- `post_install_action` - After installing the chef-client what should we do. `exec` to exec the new client or `kill` to kill the client and rely on the init system to start up the new version. Default: `exec`
+- `post_install_action` - After installing the chef-client what should we do. `exec` to exec the new client or `kill` to kill the client and rely on the init system to start up the new version. Default: `kill`
 - `exec_command` - The chef-client command. default: $PROGRAM_NAME.split(' ').first
 - `exec_args` - An array of arguments to exec the chef-client with. default: ARGV
 - `download_url_override` - The direct URL for the chef-client package.

--- a/README.md
+++ b/README.md
@@ -143,6 +143,21 @@ most likely test upgrades on your full-scale integration environment (not under 
 think that there's a rule that you must test absolutely everything you run under test-kitchen, you should probably
 [read this](http://labs.ig.com/code-coverage-100-percent-tragedy).
 
+In order to test that your recipes work under the new chef-client codebase, you should simply test your cookbooks against the new version of chef-client that you wish
+to deploy in "isolation" from the upgrade process.  If your recipes all work on the old client, and all work on the new client, and the upgrader works, then the sum
+of the parts should work as well (and again, if you really deeply care about the edge conditions where that might not work -- then test on real production-like images and
+not with test-kitchen).
+
+#### Use of 'exec' in production
+
+This is highly discouraged since the exec will not clean up the supervising process.  You're very likely to see it upgrade successfully and then see the old chef-client
+process continue to run and fork off copies of the old chef-client to run again.  Or for the upgrade process to hang, or for other issues to occur causing failed
+upgrades.
+
+You can use 'exec' in production if you are running from cron or some other process manager and firing off single-shot `--no-fork` chef-client processes without
+using the `--interval` option.  This will have the advantage that the new chef-client kicks off immediately after the upgrade giving fast feedback on any failures under
+the new chef-client.  The utility of this approach is most likely is not enough to justify the hassle.
+
 ## License & Authors
 
 - Author: Tim Smith ([tsmith@chef.io](mailto:tsmith@chef.io))

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ advice for this cookbook will be to ignore common best practices and not worry a
 in test-kitchen, then you will find sharp edge cases where your production upgrades will hang and/or fail, which testing will not replicate.  In order to test you should
 most likely test upgrades on your full-scale integration environment (not under test-kitchen) before rolling out to production and not use test-kitchen at all.  If you
 think that there's a rule that you must test absolutely everything you run under test-kitchen, you should probably
-[read this](http://labs.ig.com/code-coverage-100-percent-tragedy).
+[read this](http://labs.ig.com/code-coverage-100-percent-tragedy) or [this](https://coderanger.net/overtesting/).
 
 In order to test that your recipes work under the new chef-client codebase, you should simply test your cookbooks against the new version of chef-client that you wish
 to deploy in "isolation" from the upgrade process.  If your recipes all work on the old client, and all work on the new client, and the upgrader works, then the sum

--- a/README.md
+++ b/README.md
@@ -131,6 +131,18 @@ chef_client_updater 'Install 12.13.36 and kill' do
 end
 ```
 
+#### Test Kitchen Testing
+
+In order to test this cookbook it will be necessary to change the `post_install_action` to `exec` from `kill`.  While `kill` is better in most actual production use cases
+as it terminates the chef-client run along with cleaning up the parent process, the use of `kill` under test kitchen will fail the chef-client run and fail the
+test-kitchen run.  The use of `exec` allows test-kitchen to complete and then re-runs the recipe to validate that the cookbook does not attempt to re-update the chef-client
+and will succeed with the new chef-client.  This, however, means that it is not possible to exactly test the config which will be running in production.  The best practice
+advice for this cookbook will be to ignore common best practices and not worry about that.  If you change your production config to use `exec` in order to run what you test
+in test-kitchen, then you will find sharp edge cases where your production upgrades will hang and/or fail, which testing will not replicate.  In order to test you should
+most likely test upgrades on your full-scale integration environment (not under test-kitchen) before rolling out to production and not use test-kitchen at all.  If you
+think that there's a rule that you must test absolutely everything you run under test-kitchen, you should probably
+[read this](http://labs.ig.com/code-coverage-100-percent-tragedy).
+
 ## License & Authors
 
 - Author: Tim Smith ([tsmith@chef.io](mailto:tsmith@chef.io))

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,7 +26,7 @@ default['chef_client_updater']['prevent_downgrade'] = false
 default['chef_client_updater']['version'] = 'latest'
 
 # kill the client post install or exec the client post install for non-service based installs
-default['chef_client_updater']['post_install_action'] = 'exec'
+default['chef_client_updater']['post_install_action'] = 'kill'
 
 # the download URL (for use in an air-gapped environment)
 default['chef_client_updater']['download_url_override'] = nil

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -123,10 +123,10 @@ def eval_post_install_action
     new_resource.post_install_action = 'kill'
   end
 
-  if windows?
-    Chef::Log.warn 'forcing "exec" to "kill" on windows.'
-    new_resource.post_install_action = 'kill'
-  end
+  return unless windows?
+
+  Chef::Log.warn 'forcing "exec" to "kill" on windows.'
+  new_resource.post_install_action = 'kill'
 end
 
 def run_post_install_action

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -26,7 +26,7 @@ default_action :update
 attribute :channel, kind_of: [String, Symbol], default: :stable
 attribute :prevent_downgrade, kind_of: [TrueClass, FalseClass], default: false
 attribute :version, kind_of: [String, Symbol], default: :latest
-attribute :post_install_action, kind_of: String, default: 'exec'
+attribute :post_install_action, kind_of: String, default: 'kill'
 attribute :exec_command, kind_of: String, default: $PROGRAM_NAME.split(' ').first
 attribute :exec_args, kind_of: Array, default: ARGV
 attribute :download_url_override, kind_of: String

--- a/test/cookbooks/test/recipes/constrained.rb
+++ b/test/cookbooks/test/recipes/constrained.rb
@@ -1,3 +1,4 @@
 chef_client_updater 'Install constrained version' do
   version '12'
+  post_install_action 'exec'
 end

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -1,3 +1,4 @@
 chef_client_updater 'Install latest Chef' do
   channel 'current'
+  post_install_action 'exec'
 end

--- a/test/cookbooks/test/recipes/direct_url.rb
+++ b/test/cookbooks/test/recipes/direct_url.rb
@@ -4,4 +4,5 @@ chef_client_updater 'Install latest Chef' do
   version '12.19.36'
   download_url_override 'https://packages.chef.io/files/stable/chef/12.19.36/el/6/chef-12.19.36-1.el6.x86_64.rpm'
   checksum '89e8e6e9aebe95bb31e9514052a8926f61d82067092ca3bc976b0bd223710c81'
+  post_install_action 'exec'
 end


### PR DESCRIPTION
kill seems to clean up a lot of garbage that exec would leave behind.
