### PR TITLE
adding check for gem.cmd on chefclient 13 windows

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -50,6 +50,9 @@ end
 
 def update_rubygems
   gem_bin = "#{Gem.bindir}/gem"
+  if !::File.exist?(gem_bin) && windows?
+    gem_bin = "#{Gem.bindir}/gem.cmd" # on Chef Client 13+ the rubygem executable is gem.cmd, not gem
+  end
   raise 'cannot find omnibus install' unless ::File.exist?(gem_bin)
 
   rubygems_version = Gem::Version.new(shell_out("#{gem_bin} --version").stdout.chomp)


### PR DESCRIPTION
Signed-off-by: Trevor Hess <trevor@chef.io>

### Description

This allows Chef Client 13 to be upgraded on Windows machines

### Issues Resolved

Chef Client 13 has changed how the gem executable is deployed on Windows. It is no longer gem, but gem.cmd

### Check List
Tests will be added in a separate commit, as there are currently not tests in this cookbook outside of harness cookbooks. And no integrated test for Windows exists yet. I did test myself in Azure.

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
