### PR TITLE
Improved updating on windows and adds integration test

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -30,9 +30,19 @@ platforms:
   - name: windows-2008r2
     driver:
       box: chef/windows-server-2008r2-standard # private box in Chef's Atlas account
+    provisioner:
+      wait_for_retry: 300
+    transport:
+      name: winrm
+      elevated: true
   - name: windows-2012r2
     driver:
       box: chef/windows-server-2012r2-standard # private box in Chef's Atlas account
+    provisioner:
+      wait_for_retry: 300
+    transport:
+      name: winrm
+      elevated: true
   - name: macosx-10.11
     driver:
       box: chef/macosx-10.11 # private box in Chef's Atlas account
@@ -45,9 +55,15 @@ suites:
   - name: default
     run_list:
       - recipe[test::default]
+    excludes:
+      - windows-2008r2
+      - windows-2012r2
   - name: kill
     run_list:
       - recipe[test::kill]
+    verifier:
+      inspec_tests:
+        - path: ./test/integration/default/
   - name: direct_url
     run_list:
       - recipe[test::direct_url]

--- a/chefignore
+++ b/chefignore
@@ -104,9 +104,3 @@ Strainerfile
 ###########
 .vagrant
 Vagrantfile
-
-# GitHub #
-##########
-.delivery/*
-.github/*
-gemfiles/*

--- a/chefignore
+++ b/chefignore
@@ -104,3 +104,9 @@ Strainerfile
 ###########
 .vagrant
 Vagrantfile
+
+# GitHub #
+##########
+.delivery/*
+.github/*
+gemfiles/*

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,6 +6,8 @@ description 'Upgrades chef-client to specified releases'
 long_description 'Upgrades chef-client to specified releases'
 version '3.0.4'
 
+chef_version '>= 11' if respond_to?(:chef_version)
+
 %w(amazon centos debian mac_os_x opensuse opensuseleap oracle redhat scientific solaris2 suse ubuntu windows aix).each do |os|
   supports os
 end

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -256,7 +256,7 @@ def execute_install_script(install_script)
           c:/windows/system32/schtasks.exe /delete /f /tn Chef_upgrade
 
           Get-Service chef-client -ErrorAction SilentlyContinue | Start-service
-          c:/opscode/chef/bin/chef-client.bat
+          #{chef_install_dir}/bin/chef-client.bat
         }
 
         $http_proxy = $env:http_proxy

--- a/test/cookbooks/test/attributes/default.rb
+++ b/test/cookbooks/test/attributes/default.rb
@@ -1,0 +1,1 @@
+override['chef_client_updater']['version'] = '13.6.0'

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -1,4 +1,5 @@
-chef_client_updater 'Install latest Chef' do
+chef_client_updater "Install Chef #{node['chef_client_updater']['version']}" do
   channel 'current'
+  version node['chef_client_updater']['version']
   post_install_action 'exec'
 end

--- a/test/cookbooks/test/recipes/kill.rb
+++ b/test/cookbooks/test/recipes/kill.rb
@@ -1,4 +1,5 @@
-chef_client_updater 'Install latest Chef' do
+chef_client_updater "Install Chef #{node['chef_client_updater']['version']}" do
   channel 'current'
+  verison node['chef_client_updater']['version']
   post_install_action 'kill'
 end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,0 +1,3 @@
+describe command('chef-client -v') do
+  its('stdout') { should match '^Chef: 13.6.0' }
+end


### PR DESCRIPTION
### Description

Basically upgrading by moving the Chef install directory on windows had a high failure rate. This changes the move to copy-and-cleanup-in-next-run.

This includes the changes in https://github.com/chef-cookbooks/chef_client_updater/pull/67 but squashed in one commit. 

Also updates testing.

### Issues Resolved

File locks within the C:\opscode\Chef folder potentially result in a corrupt Chef install on Windows systems. The use of Ruby FileUtils.mv iterates over the folder subitems, moving unlocked files to dest folder but leaving locked files in src folder. This effectively breaks the Chef install.
The Powershell Rename-Item function does all-or-nothing. So you end up with the new version, or your old version will still be intact.
the Chef run doing the upgrade itself locks some DLLs in the embedded/bin folder (ie libeay32.dll), resulting in a high fail rate of the folder move / rename. 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>