### PR TITLE
Windows: Bypass Powershell Execution Policy for upgrade scheduled task

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -237,7 +237,7 @@ end
 
 def prepare_windows
   copy_opt_chef(chef_install_dir, chef_backup_dir)
-  Kernel.spawn('c:/windows/system32/schtasks.exe /F /RU SYSTEM /create /sc minute /mo 1 /tn Chef_upgrade /tr "powershell.exe c:/opscode/chef_upgrade.ps1"')
+  Kernel.spawn('c:/windows/system32/schtasks.exe /F /RU SYSTEM /create /sc minute /mo 1 /tn Chef_upgrade /tr "powershell.exe -ExecutionPolicy Bypass c:/opscode/chef_upgrade.ps1"')
   FileUtils.rm_rf "#{chef_install_dir}/bin/chef-client.bat"
 end
 


### PR DESCRIPTION
Signed-off-by: Charlie Roffe <charlie@roffe.net>

### Description

Increases effectiveness of upgrade scheduled task.  Previously, upgrade scheduled task would fail if Powershell Execution Policy is too restricted.  This will bypass the Powershell Execution Policy for the upgrade.

### Issues Resolved

https://github.com/chef-cookbooks/chef_client_updater/issues/75

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
