### PR TITLE
Post action support on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Installs the mixlib-install/mixlib-install gems and upgrades the chef-client.
 - `prevent_downgrade` - Don't allow this cookbook to downgrade the chef-client version. Default: false
 - `version` - The version of the chef-client to install. Default :latest
 - `post_install_action` - After installing the chef-client what should we do. `exec` to exec the new client or `kill` to kill the client and rely on the init system to start up the new version. Default: `kill`
-- `exec_command` - The chef-client command. default: $PROGRAM_NAME.split(' ').first
+- `exec_command` - The chef-client command. default: $PROGRAM_NAME.split(' ').first. You can also enter a custom post-action command.
 - `exec_args` - An array of arguments to exec the chef-client with. default: ARGV
 - `download_url_override` - The direct URL for the chef-client package.
 - `checksum` - The SHA-256 checksum of the chef-client package from the direct URL.

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -243,6 +243,12 @@ end
 
 def execute_install_script(install_script)
   if windows?
+    post_action = if new_resource.post_install_action == 'exec'
+                    new_resource.exec_command
+                  else
+                    ''
+                  end
+
     powershell_script 'name' do
       code <<-EOH
         $command = {
@@ -259,8 +265,7 @@ def execute_install_script(install_script)
           Remove-Item "c:/opscode/chef_upgrade.ps1"
           c:/windows/system32/schtasks.exe /delete /f /tn Chef_upgrade
 
-          Get-Service chef-client -ErrorAction SilentlyContinue | Start-service
-          #{chef_install_dir}/bin/chef-client.bat
+          #{post_action}
         }
 
         $http_proxy = $env:http_proxy


### PR DESCRIPTION
Signed-off-by: Robbert-Jan Sperna Weiland <rspernaweiland@schubergphilis.com>

### Description

Post action support on Windows, and generally making the post_install_action more in line with the way Linux handles it:
* Declaring `post_install_action` `'exec'` makes Chef run after the upgrade just like it is running during upgrade (same default as on Linux)
* Declaring `post_install_action` `'exec'` and a Powershell-compatible `exec_command ` makes Chef run the custom command after upgrade instead. Ie:
`exec_command 'shutdown /r /t 0'`
* Declaring `post_install_action` `'kill'` runs nothing after upgrade.

### Issues Resolved

#71 
