### PR TITLE
Alow custom paths to chef-client.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,3 +33,7 @@ default['chef_client_updater']['download_url_override'] = nil
 
 # the checksum of the package from "download_url_override"
 default['chef_client_updater']['checksum'] = nil
+
+# Root installation path for chef-client for when a custom path is used.
+# Defaults to 'C:/opscode/chef' on Windows and '/opt/chef' for everything else.
+default['chef_client_updater']['chef_install_path'] = nil

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -81,7 +81,7 @@ def mixlib_install
   detected_platform = Mixlib::Install.detect_platform
   Chef::Log.debug("Platform detected as #{detected_platform} by mixlib_install")
   options = {
-    product_name: 'chef',
+    product_name: node['chef_client_updater']['product_name'] || 'chef',
     platform_version_compatibility_mode: true,
     platform: detected_platform[:platform],
     platform_version: detected_platform[:platform_version],
@@ -180,11 +180,11 @@ def run_post_install_action
 end
 
 def chef_install_dir
-  windows? ? 'c:/opscode/chef' : '/opt/chef'
+  node['chef_client_updater']['chef_install_path'] || windows? ? 'c:/opscode/chef' : '/opt/chef'
 end
 
 def chef_backup_dir
-  windows? ? 'c:/opscode/chef.upgrade' : '/opt/chef.upgrade'
+  "#{chef_install_dir}.upgrade"
 end
 
 # cleanup cruft from *prior* runs


### PR DESCRIPTION
### Description

We use Chef to manage the internal build infrastructure which is used to build Chef. In order to have a reliable chef-client and reproducible builds we use "angrychef" on these nodes which installs under
`/opt/angrychef` rather than the default `/opt/chef` path.

### Issues Resolved

- Issue #68 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>

/cc  @jaymalasinha @scotthain @schisamo @tduffield