### PR TITLE
 If the user provides an X.Y.Z format version don't contact omnitruck

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,7 +8,7 @@ provisioner:
     - 213
   max_retries: 1
   wait_for_retry: 1
-  client_rb:
+  solo_rb:
     exit_status: :enabled
     client_fork: false
 

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -71,3 +71,7 @@ suites:
     run_list:
       - recipe[test::constrained]
     includes: centos-6
+  - name: noop
+    run_list:
+      - recipe[test::noop]
+    includes: centos-6

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -114,15 +114,17 @@ def desired_version
   if new_resource.version.to_sym == :latest # we need to find what :latest really means
     version = Mixlib::Versioning.parse(mixlib_install.available_versions.last)
     Chef::Log.debug("User specified version of :latest. Looking up using mixlib-install. Value maps to #{version}.")
-    version
+  elsif new_resource.download_url_override # probably in an air-gapped environment.
+    version = Mixlib::Versioning.parse(new_resource.version)
+    Chef::Log.debug("download_url_override specified. Using specified version of #{version}")
   elsif new_resource.version.split('.').count == 3 # X.Y.Z version format given
     Chef::Log.debug("User specified version of #{new_resource.version}. No need check this against Chef servers.")
-    Mixlib::Versioning.parse(new_resource.version)
+    version = Mixlib::Versioning.parse(new_resource.version)
   else # lookup their shortened version to find the X.Y.Z version
     version = Mixlib::Versioning.parse(Array(mixlib_install.artifact_info).first.version)
     Chef::Log.debug("User specified version of #{new_resource.version}. Looking up using mixlib-install as this is not X.Y.Z format. Value maps to #{version}.")
-    version
   end
+  version
 end
 
 # why wouldn't we use the built in update_available? method in mixlib-install?

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -101,28 +101,28 @@ end
 # why would we use this when mixlib-install has a current_version method?
 # well mixlib-version parses the manifest JSON, which might not be there.
 # ohai handles this better IMO
+# @return String
 def current_version
   node['chef_packages']['chef']['version']
 end
 
-# the version we WANT TO INSTALL. If :latest is specified this will be the actual
-# latest version returned by mixlib-install. if download_url_override is passed
-# we parse the version, but blindly assume it's correct. Otherwise we rely on
-# mixlib-install to give us the exact version since someone could pass ~12 which
-# needs to be expanded to the latest 12.X.
+# the version we WANT TO INSTALL. If the user specifies a version in X.Y.X format
+# we use that without looking it up. If :latest or a non-X.Y.Z format version we
+# look it up with mixlib-install to determine the latest version matching the request
+# @return Mixlib::Versioning::Format::PartialSemVer
 def desired_version
-  if new_resource.download_url_override
-    # probably in an air-gapped environment.
-    version = Mixlib::Versioning.parse(new_resource.version)
-    Chef::Log.debug("download_url_override specified. Using specified version of #{version}")
-  elsif new_resource.version.to_sym == :latest
+  if new_resource.version.to_sym == :latest # we need to find what :latest really means
     version = Mixlib::Versioning.parse(mixlib_install.available_versions.last)
-    Chef::Log.debug("Version set to :latest, which currently maps to #{version}")
-  else
+    Chef::Log.debug("User specified version of :latest. Looking up using mixlib-install. Value maps to #{version}.")
+    version
+  elsif new_resource.version.split('.').count == 3 # X.Y.Z version format given
+    Chef::Log.debug("User specified version of #{new_resource.version}. No need check this against Chef servers.")
+    Mixlib::Versioning.parse(new_resource.version)
+  else # lookup their shortened version to find the X.Y.Z version
     version = Mixlib::Versioning.parse(Array(mixlib_install.artifact_info).first.version)
-    Chef::Log.debug("Desired version in specified channel maps to #{version}")
+    Chef::Log.debug("User specified version of #{new_resource.version}. Looking up using mixlib-install as this is not X.Y.Z format. Value maps to #{version}.")
+    version
   end
-  version
 end
 
 # why wouldn't we use the built in update_available? method in mixlib-install?
@@ -135,7 +135,7 @@ def update_necessary?
 
   Chef::Log.debug("The current chef-client version is #{cur_version} and the desired version is #{des_version}")
   necessary = new_resource.prevent_downgrade ? (des_version > cur_version) : (des_version != cur_version)
-  Chef::Log.debug("A chef-client upgrade #{necessary == true ? "is" : "isn't"} necessary")
+  Chef::Log.debug("A chef-client upgrade #{necessary == true ? 'is' : "isn't"} necessary")
   necessary
 end
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -134,7 +134,9 @@ def update_necessary?
   des_version = desired_version
 
   Chef::Log.debug("The current chef-client version is #{cur_version} and the desired version is #{des_version}")
-  new_resource.prevent_downgrade ? (des_version > cur_version) : (des_version != cur_version)
+  necessary = new_resource.prevent_downgrade ? (des_version > cur_version) : (des_version != cur_version)
+  Chef::Log.debug("A chef-client upgrade #{necessary == true ? "is" : "isn't"} necessary")
+  necessary
 end
 
 def eval_post_install_action

--- a/test/cookbooks/test/recipes/noop.rb
+++ b/test/cookbooks/test/recipes/noop.rb
@@ -1,0 +1,5 @@
+chef_client_updater "Install Chef #{node['chef_client_updater']['version']}" do
+  channel 'current'
+  version '12.13.37'
+  post_install_action 'kill'
+end


### PR DESCRIPTION
If someone gives us these we do need to lookup a full version string:

12.5
12
:latest

If someone gives us this we don't:

12.13.7

This removes load on our systems, speeds up the run, and allows the run to continue if those servers are down.

Signed-off-by: Tim Smith <tsmith@chef.io>