### PR TITLE
error out chef run if shell update fails

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -311,7 +311,7 @@ def execute_install_script(install_script)
   else
     upgrade_command = Mixlib::ShellOut.new(install_script)
     upgrade_command.run_command
-    if upgrade_command.error?
+    if upgrade_command.exitstatus != 0
       raise "Error updating chef-client. exit code: #{upgrade_command.exitstatus}.\nSTDERR: #{upgrade_command.stderr}\nSTDOUT: #{upgrade_command.stdout}"
     end
   end

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -311,6 +311,9 @@ def execute_install_script(install_script)
   else
     upgrade_command = Mixlib::ShellOut.new(install_script)
     upgrade_command.run_command
+    if upgrade_command.error?
+      raise "Error updating chef-client. exit code: #{upgrade_command.exitstatus}.\nSTDERR: #{upgrade_command.stderr}\nSTDOUT: #{upgrade_command.stdout}"
+    end
   end
 end
 


### PR DESCRIPTION
### Description

This change makes it so if there is an error install chef with the shell snippet Mixlib::Install generates it will fail the chef run. Currently if it fails it will silently ignore and continue. This causes all sorts of havoc like the chef-client command no longer working. 

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
