### PR TITLE
rubygems_url: Allow the rubygems source to be specified

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -75,3 +75,13 @@ suites:
     run_list:
       - recipe[test::noop]
     includes: centos-6
+  - name: rubygems-url
+    run_list:
+      - recipe[test::gem_server]
+      - recipe[test::rubygems_url]
+    includes: ubuntu-16.04
+    driver:
+      require_chef_omnibus: 12.13.37
+    verifier:
+      inspec_tests:
+        - path: ./test/integration/default/

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Installs the mixlib-install/mixlib-install gems and upgrades the chef-client.
 - `checksum` - The SHA-256 checksum of the chef-client package from the direct URL.
 - `upgrade_delay` - The delay in seconds before the scheduled task to upgrade chef-client runs on windows. default: 61. Lowering this limit is not recommended.
 - `product_name` - The name of the product to upgrade. This can be `chef` or `chefdk` default: chef
+- `rubygems_url` - The location to source rubygems. Replaces the default https://www.rubygems.org.
 
 #### examples
 

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -40,3 +40,4 @@ attribute :checksum, kind_of: String
 # Lowering upgrade_delay limit is not recommended.
 attribute :upgrade_delay, kind_of: Integer, default: 60
 attribute :product_name, kind_of: String, default: 'chef'
+attribute :rubygems_url, kind_of: String

--- a/test/cookbooks/test/recipes/gem_server.rb
+++ b/test/cookbooks/test/recipes/gem_server.rb
@@ -1,0 +1,32 @@
+# Build a gem server for testing
+
+rubygems_ips = shell_out('dig +short rubygems.org').stdout.split("\n")
+deny_rubygems = rubygems_ips.map do |rubygems_ip|
+  "ufw deny out from any to #{rubygems_ip}"
+end.join("\n")
+
+bash 'local gem server' do
+  code <<-EOH
+#!/bin/bash -x
+pkill -9 gem
+apt-get -q -y update
+apt-get -q -y install ruby2.3
+if [[ -z `/usr/bin/gem list 'mixlib-install'` ]]; then
+  /usr/bin/gem install 'mixlib-install'
+  /usr/bin/gem install 'mixlib-versioning'
+  /usr/bin/gem install 'thor' -v '0.20.0'
+fi
+/usr/bin/gem server -d /var/lib/gems/2.3.0 2>/dev/null 1>/dev/null </dev/null &
+apt-get -q -y install ufw
+ufw --force enable
+ufw allow ssh
+#{deny_rubygems}
+EOH
+end
+
+# This step should fail if the firewall rules work
+chef_gem 'chef-ruby-lvm' do
+  compile_time false
+  ignore_failure true
+  timeout 15
+end

--- a/test/cookbooks/test/recipes/rubygems_url.rb
+++ b/test/cookbooks/test/recipes/rubygems_url.rb
@@ -1,0 +1,5 @@
+chef_client_updater 'Install latest Chef' do
+  version '13.6.0'
+  rubygems_url 'http://localhost:8808'
+  post_install_action 'exec'
+end

--- a/test/cookbooks/test/templates/default/ufw_chef.erb
+++ b/test/cookbooks/test/templates/default/ufw_chef.erb
@@ -1,0 +1,5 @@
+# position 50
+ufw allow in proto tcp to any port 22 from any
+<% @rubygems_ips.each do |rubygems_ip| %>
+<%= "ufw deny in proto tcp to #{rubygems_ip} from any" %>
+<% end %>


### PR DESCRIPTION
Allow the rubygems server to be specified for isolated environments.

Signed-off-by: markgibbons <mark.gibbons@nordstrom.com>

### Description

Allow the ruby gems source to be specified.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>