### PR TITLE
Fix warning '/ST is earlier than current time'

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,6 +24,6 @@ chef_client_updater 'update chef-client' do
   post_install_action node['chef_client_updater']['post_install_action']
   download_url_override node['chef_client_updater']['download_url_override'] if node['chef_client_updater']['download_url_override']
   checksum node['chef_client_updater']['checksum'] if node['chef_client_updater']['checksum']
-  upgrade_delay node['chef_client_updater']['upgrade_delay'] if node['chef_client_updater']['upgrade_delay']
+  upgrade_delay node['chef_client_updater']['upgrade_delay'].nil? ? 30 : node['chef_client_updater']['upgrade_delay']
   product_name node['chef_client_updater']['product_name'] if node['chef_client_updater']['product_name']
 end


### PR DESCRIPTION
Signed-off-by: Yury Levin <iamyura@gmail.com>

### Description
This commit resolves issue with warning

$$$$$$ chef-client.bat : WARNING: Task may not run because /ST is earlier than current time.

described at https://github.com/chef-cookbooks/chef_client_updater/pull/87#issuecomment-360745209

This issue probably prevents Chef client from being upgraded.