### PR TITLE
Change default upgrade delay to 61 seconds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Installs the mixlib-install/mixlib-install gems and upgrades the chef-client.
 - `exec_args` - An array of arguments to exec the chef-client with. default: ARGV
 - `download_url_override` - The direct URL for the chef-client package.
 - `checksum` - The SHA-256 checksum of the chef-client package from the direct URL.
-- `upgrade_delay` - The delay in seconds before the scheduled task to upgrade chef-client runs on windows. default: 61. Lowering this limit is not recommended, there is a risk to schedule upgrade within the same minute that Chef runs and upgrade won't be triggered.
+- `upgrade_delay` - The delay in seconds before the scheduled task to upgrade chef-client runs on windows. default: 61. Lowering this limit is not recommended.
 - `product_name` - The name of the product to upgrade. This can be `chef` or `chefdk` default: chef
 
 #### examples

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Installs the mixlib-install/mixlib-install gems and upgrades the chef-client.
 - `exec_args` - An array of arguments to exec the chef-client with. default: ARGV
 - `download_url_override` - The direct URL for the chef-client package.
 - `checksum` - The SHA-256 checksum of the chef-client package from the direct URL.
-- `upgrade_delay` - The delay in seconds before the scheduled task to upgrade chef-client runs on windows. default: 61. When using values 60 seconds or less, there is a risk to schedule upgrade within the same minute that Chef runs and upgrade won't be triggered.
+- `upgrade_delay` - The delay in seconds before the scheduled task to upgrade chef-client runs on windows. default: 61. Lowering this limit is not recommended, there is a risk to schedule upgrade within the same minute that Chef runs and upgrade won't be triggered.
 - `product_name` - The name of the product to upgrade. This can be `chef` or `chefdk` default: chef
 
 #### examples

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Installs the mixlib-install/mixlib-install gems and upgrades the chef-client.
 - `exec_args` - An array of arguments to exec the chef-client with. default: ARGV
 - `download_url_override` - The direct URL for the chef-client package.
 - `checksum` - The SHA-256 checksum of the chef-client package from the direct URL.
-- `upgrade_delay` - The delay in seconds before the scheduled task to upgrade chef-client runs on windows. default: 30
+- `upgrade_delay` - The delay in seconds before the scheduled task to upgrade chef-client runs on windows. default: 61. When using values 60 seconds or less, there is a risk to schedule upgrade within the same minute that Chef runs and upgrade won't be triggered.
 - `product_name` - The name of the product to upgrade. This can be `chef` or `chefdk` default: chef
 
 #### examples

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,6 +24,6 @@ chef_client_updater 'update chef-client' do
   post_install_action node['chef_client_updater']['post_install_action']
   download_url_override node['chef_client_updater']['download_url_override'] if node['chef_client_updater']['download_url_override']
   checksum node['chef_client_updater']['checksum'] if node['chef_client_updater']['checksum']
-  upgrade_delay node['chef_client_updater']['upgrade_delay'].nil? ? 30 : node['chef_client_updater']['upgrade_delay']
+  upgrade_delay node['chef_client_updater']['upgrade_delay'].nil? ? 61 : node['chef_client_updater']['upgrade_delay']
   product_name node['chef_client_updater']['product_name'] if node['chef_client_updater']['product_name']
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,6 +24,6 @@ chef_client_updater 'update chef-client' do
   post_install_action node['chef_client_updater']['post_install_action']
   download_url_override node['chef_client_updater']['download_url_override'] if node['chef_client_updater']['download_url_override']
   checksum node['chef_client_updater']['checksum'] if node['chef_client_updater']['checksum']
-  upgrade_delay node['chef_client_updater']['upgrade_delay'].nil? ? 61 : node['chef_client_updater']['upgrade_delay']
+  upgrade_delay node['chef_client_updater']['upgrade_delay'] unless node['chef_client_updater']['upgrade_delay'].nil?
   product_name node['chef_client_updater']['product_name'] if node['chef_client_updater']['product_name']
 end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -35,5 +35,8 @@ attribute :exec_command, kind_of: String, default: $PROGRAM_NAME.split(' ').firs
 attribute :exec_args, kind_of: Array, default: ARGV
 attribute :download_url_override, kind_of: String
 attribute :checksum, kind_of: String
+# If the upgrade is scheduled in the same minute that Chef runs,
+# there is a risk the upgrade will not be triggered.
+# Lowering upgrade_delay limit is not recommended.
 attribute :upgrade_delay, kind_of: Integer, default: 61
 attribute :product_name, kind_of: String, default: 'chef'

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -35,5 +35,5 @@ attribute :exec_command, kind_of: String, default: $PROGRAM_NAME.split(' ').firs
 attribute :exec_args, kind_of: Array, default: ARGV
 attribute :download_url_override, kind_of: String
 attribute :checksum, kind_of: String
-attribute :upgrade_delay, kind_of: Integer, default: 30
+attribute :upgrade_delay, kind_of: Integer, default: 61
 attribute :product_name, kind_of: String, default: 'chef'

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -38,5 +38,5 @@ attribute :checksum, kind_of: String
 # If the upgrade is scheduled in the same minute that Chef runs,
 # there is a risk the upgrade will not be triggered.
 # Lowering upgrade_delay limit is not recommended.
-attribute :upgrade_delay, kind_of: Integer, default: 61
+attribute :upgrade_delay, kind_of: Integer, default: 60
 attribute :product_name, kind_of: String, default: 'chef'


### PR DESCRIPTION
### Description

Change default upgrade delay to 61 seconds.

### Issues Resolved

This eliminate warning "Task may not run because /ST is earlier than current time." that still might appear if task is being scheduled within 1-30 seconds of any minute and if default delay 30 seconds is used.

