### PR TITLE
Update rubygems fix

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -48,3 +48,9 @@ suites:
   - name: constrained
     run_list:
       - recipe[test::constrained]
+  - name: noop
+    run_list:
+      - recipe[test::default]
+    attributes:
+      chef_client_updater:
+        version: '<%= ENV["OMNIBUS_CHEF_VERSION"] || "11.18.12" %>'

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -24,8 +24,6 @@
 
 use_inline_resources
 
-include Chef::Mixin::ShellOut
-
 provides :chef_client_updater if respond_to?(:provides)
 
 def load_mixlib_install
@@ -53,20 +51,15 @@ rescue LoadError
 end
 
 def update_rubygems
-  gem_bin = "#{Gem.bindir}/gem"
-  if !::File.exist?(gem_bin) && windows?
-    gem_bin = "#{Gem.bindir}/gem.cmd" # on Chef Client 13+ the rubygem executable is gem.cmd, not gem
-  end
-  raise 'cannot find omnibus install' unless ::File.exist?(gem_bin)
-
-  rubygems_version = Gem::Version.new(shell_out("#{gem_bin} --version").stdout.chomp)
+  rubygems_version = Gem::VERSION
   target_version = '2.6.11'
   Chef::Log.debug("Found gem version #{rubygems_version}. Desired version is at least #{target_version}")
   return if Gem::Requirement.new(">= #{target_version}").satisfied_by?(rubygems_version)
 
   converge_by "upgrade rubygems #{rubygems_version} to latest" do
     # note that the rubygems that we're upgrading is likely so old that you can't pin a version
-    shell_out!("#{gem_bin} update --system --no-rdoc --no-ri")
+    require 'rubygems/commands/update_command'
+    Gem::Commands::UpdateCommand.new.invoke '--system', '--no-rdoc', '--no-ri'
   end
 end
 

--- a/test/cookbooks/test/attributes/default.rb
+++ b/test/cookbooks/test/attributes/default.rb
@@ -1,1 +1,1 @@
-override['chef_client_updater']['version'] = '13.6.0'
+default['chef_client_updater']['version'] = '13.6.0'

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,3 +1,7 @@
 describe command('chef-client -v') do
   its('stdout') { should match '^Chef: 13.6.0' }
 end
+
+describe command('/opt/chef/embedded/bin/gem -v') do
+  its('stdout') { should cmp >= '2.6.11' }
+end

--- a/test/integration/noop/noop_spec.rb
+++ b/test/integration/noop/noop_spec.rb
@@ -1,0 +1,26 @@
+# For the noop suite, currently-installed and target Chef versions are equal.
+gem_path = '/opt/chef/embedded/bin/gem'
+chef_version = Gem::Version.new(ENV['OMNIBUS_CHEF_VERSION'] || '11.18.12')
+
+describe command("#{gem_path} -v") do
+  # First version of Chef with bundled Rubygems >= 2.0.0.
+  min_chef_version = '11.18.0'
+
+  min_rubygems_version = '2.0.0'
+  target_rubygems_version = '2.6.11'
+
+  if Gem::Requirement.new(">= #{min_chef_version}").satisfied_by?(chef_version)
+    its('stdout') { should cmp >= min_rubygems_version }
+  else
+    # Old Chef versions should upgrade old Rubygems to the target version.
+    its('stdout') { should match target_rubygems_version }
+  end
+end
+
+describe gem('mixlib-install', gem_path) do
+  it { should be_installed }
+end
+
+describe gem('mixlib-versioning', gem_path) do
+  it { should be_installed }
+end


### PR DESCRIPTION
### Description

Improves the logic around upgrading Rubygems in Chef's embedded Ruby installation:

- Rubygems isn't upgraded unless the version currently installed is old (specifically, if the rubygems version is so old that it won't install mixlib-install from gems, as noted in #19).
  - Expanded the compatible Rubygems version range from `>= 2.6.11` to `>= 2.0.0`; however, in my tests with earlier Chef versions (e.g.,. `11.16.0`), earlier 1.x versions of Rubygems also seemed to install `mixlib-install` from gems via the cookbook without issue. Reproducing the issue mentioned in #19 with more detail could help narrow/expand this compatibility range further.
- When necessary, Rubygems is only upgraded to a fixed version (so the cookbook behavior is deterministic).
  - Set the target-install version to `2.6.11`, which was the previously-existing minimum compatible Rubygems version range.
  - Replaced `shell_out` with `Gem::Commands::UpdateCommand` API call, to simplify the logic and for broader compatibility running Chef-Client from ruby installations in different paths (e.g., from Ubuntu package-installed system Ruby).
  - According to the [Rubygems documentation](https://github.com/rubygems/rubygems/blob/master/UPGRADING.rdoc#with-rubygems-152-and-higher), versions `1.5.2` and higher support the option to upgrade Rubygems to a specific version. Versions earlier than this will still upgrade to the latest version. (However, even Chef 11.0.0 comes packaged with Rubygems `1.8.24`, so it's highly unlikely an older version will ever be used with this cookbook.)

### Issues Resolved

#92

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable [not applicable]
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
