### PR TITLE
Use KILL instead of TERM on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
         - cookstyle --version
         - foodcritic --version
         - chef exec delivery local all
-    - rvm: 2.4.1
+    - rvm: 2.4.3
       services: docker
       sudo: required
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
       before_script:
         - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
       env:
-        - OMNIBUS_CHEF_VERSION=13
+        - OMNIBUS_CHEF_VERSION=13.6.4
         - KITCHEN_YAML=.kitchen.dokken.yml
       script:
         # this tests a downgrade from latest "13" to latest "12" via partial versions

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -174,7 +174,7 @@ def run_post_install_action
   when 'kill'
     if Chef::Config[:client_fork] && Process.ppid != 1 && !windows?
       Chef::Log.warn 'Chef client is running forked with a supervisor. Sending TERM to parent process!'
-      Process.kill('TERM', Process.ppid)
+      Process.kill('KILL', Process.ppid)
     end
     Chef::Log.warn 'New chef-client installed and exit is allowed. Forcing chef exit!'
     exit(213)


### PR DESCRIPTION
Signed-off-by: Scott Hain <shain@chef.io>

### Description

Sometimes chef-client doesn't respect the TERM signal and will be left orphaned on a machine. This is highly problematic when you upgrade regularly.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
