### PR TITLE
Update log message to KILL from TERM

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -173,7 +173,7 @@ def run_post_install_action
     Kernel.exec(new_resource.exec_command, *new_resource.exec_args)
   when 'kill'
     if Chef::Config[:client_fork] && Process.ppid != 1 && !windows?
-      Chef::Log.warn 'Chef client is running forked with a supervisor. Sending TERM to parent process!'
+      Chef::Log.warn 'Chef client is running forked with a supervisor. Sending KILL to parent process!'
       Process.kill('KILL', Process.ppid)
     end
     Chef::Log.warn 'New chef-client installed and exit is allowed. Forcing chef exit!'


### PR DESCRIPTION
In #94 we changed the signal from TERM to KILL but the log message still
indicates that we're sending a TERM. This change aligns the log with the signal.