### PR TITLE
Restart chef-client with cron under sysvinit

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# When running under init this cron job is created after an update
+cron 'chef_client_updater' do
+  action :delete
+end
+
 chef_client_updater 'update chef-client' do
   channel node['chef_client_updater']['channel']
   version node['chef_client_updater']['version']


### PR DESCRIPTION
Normally we rely on a supervisor to restart chef-client after upgrade,
but in this case we can try to restart under sysvinit by using cron to
schedule the service to start again.