### PR TITLE
Fix custom install path

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -184,7 +184,7 @@ def run_post_install_action
 end
 
 def chef_install_dir
-  node['chef_client_updater']['chef_install_path'] || windows? ? 'c:/opscode/chef' : '/opt/chef'
+  node['chef_client_updater']['chef_install_path'] || (windows? ? 'c:/opscode/chef' : '/opt/chef')
 end
 
 def chef_backup_dir


### PR DESCRIPTION
Signed-off-by: Scott Hain <shain@chef.io>

### Description

When `node['chef_client_updater']['chef_install_path']` is specified, `chef_install_path` resolves to 'c:/opscode/chef'

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
