### PR TITLE
[GH-108] - stopped Push Jobs

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -297,8 +297,12 @@ def execute_install_script(install_script)
       code <<-EOH
         $command = {
           Get-Service chef-client -ErrorAction SilentlyContinue | stop-service
+          Get-Service push-jobs-client -ErrorAction SilentlyContinue | stop-service
 
-          if ((Get-WmiObject Win32_Process -Filter "name = 'ruby.exe'" | Select-Object CommandLine | select-string 'opscode').count -gt 0) { exit 8 }
+          if ((Get-WmiObject Win32_Process -Filter "name = 'ruby.exe'" | Select-Object CommandLine | select-string 'opscode').count -gt 0) {
+            Write-Output "Chef cannot be upgraded while in use. Exiting..."
+            exit 8
+          }
 
           Remove-Item "#{chef_install_dir}" -Recurse -Force
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -315,6 +315,8 @@ def execute_install_script(install_script)
           c:/windows/system32/schtasks.exe /delete /f /tn Chef_upgrade
 
           #{post_action}
+
+          Get-Service push-jobs-client -ErrorAction SilentlyContinue | start-service
         }
 
         $http_proxy = $env:http_proxy


### PR DESCRIPTION
* stopped Push Jobs service before upgrading
* added exit message
Signed-off-by: Annie Hedgpeth <annie.hedgpeth@gmail.com>

### Description
This changes stops the Push Jobs service since it uses `ruby.exe`.

### Issues Resolved
#108 

### Check List
- [n/a] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
 _Can't load the bento boxes on my workstation._
- [X] New functionality includes testing.
_Ran the ps1 manually on a node that had Push Jobs running._
- [n/a] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
