### PR TITLE
handle cron job service restart on AIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This cookbook provides both a custom resource and a default recipe. The default 
 
 When Chef runs as a service under a system init daemon such as Sys-V or systemd each chef run forks off from the main chef-client process being managed by the init system. For a chef-client upgrade to occur, the running chef-client as well as the parent process must be killed, and a new chef-client must start using the updated binaries. This cookbook handles killing the chef-client, but your init system must properly handle starting the service back up. For systemd and upstart this can be handled via configuration, and chef-client cookbook 8.1.1 or later handles this by default. This functionality is not available in sys-v (RHEL 6, Debian 7, AIX and others).
 
-For systems where the init system will not properly handle starting the service back up automatically (like Sys-V or SRC) this cookbook will attempt to restart the service via a temporal cron job when either of the following conditions are met:
+For systems where the init system will not properly handle starting the service back up automatically (like Sys-V or SRC) this cookbook will attempt to restart the service via a temporary cron job when either of the following conditions are met:
 
   * node['chef_client']['init_style'] == 'init'
   * node['chef_client_updater']['restart_chef_via_cron'] == true

--- a/README.md
+++ b/README.md
@@ -20,7 +20,12 @@ This cookbook provides both a custom resource and a default recipe. The default 
 
 ### Init System Caveats
 
-When Chef runs as a service under a system init daemon such as Sys-V or systemd each chef run forks off from the main chef-client process being managed by the init system. For a chef-client upgrade to occur the running chef-client as well as the parent process must be killed, and a new chef-client must start using the updated binaries. This cookbook handles killing the chef-client, but your init system must properly handle starting the service back up. For systemd and upstart this can be handled via configuration, and chef-client cookbook 8.1.1 or later handles this by default. This functionality is not available in sys-v (RHEL 6, Debian 7, and others), so you will need to employ a secondary process such as a monitoring system to start the chef-client service.
+When Chef runs as a service under a system init daemon such as Sys-V or systemd each chef run forks off from the main chef-client process being managed by the init system. For a chef-client upgrade to occur, the running chef-client as well as the parent process must be killed, and a new chef-client must start using the updated binaries. This cookbook handles killing the chef-client, but your init system must properly handle starting the service back up. For systemd and upstart this can be handled via configuration, and chef-client cookbook 8.1.1 or later handles this by default. This functionality is not available in sys-v (RHEL 6, Debian 7, AIX and others).
+
+For systems where the init system will not properly handle starting the service back up automatically (like Sys-V or SRC) this cookbook will attempt to restart the service via a temporal cron job when either of the following conditions are met:
+
+  * node['chef_client']['init_style'] == 'init'
+  * node['chef_client_updater']['restart_chef_via_cron'] == true
 
 ### Updating Windows Nodes
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -360,9 +360,15 @@ action :update do
     # sysvinit won't restart after we exit, potentially use cron to do so
     # either trust the chef-client cookbook's init scripts or the users choice
     if (node['chef_client'] && node['chef_client']['init_style'] == 'init') || node['chef_client_updater']['restart_chef_via_cron']
+      start_cmd = case node['platform_family']
+                  when 'aix'
+                    '/usr/bin/startsrc -s chef > /dev/console 2>&1'
+                  else
+                    '/etc/init.d/chef-client start'
+                  end
+
       r = cron 'chef_client_updater' do
-        minute '*/1'
-        command '/etc/init.d/chef-client start'
+        command start_cmd
       end
 
       r.run_action(:create)


### PR DESCRIPTION
### Description

This change does two things:
 
 * Further clarifies the relatively [new](https://github.com/chef-cookbooks/chef_client_updater/pull/102) `restart_chef_via_cron` functionality in the `README.md`
 * Introduces a Platform case statement for defining the command necessary to restart the service via the cron job. 

For AIX, the `chef-client` cookbook activates the service via the SRC init style. This init system requires a specific command to start which is different from the typical `/etc/init.d/chef-client start` of Sys-V systems. 

The Platform case statement handles this difference and could also be used for other platforms as well 😃 

![animated_cute_dancing_monsters_mummy_dracula_frankenstein_wolfman-1](https://user-images.githubusercontent.com/1991696/39312846-1aeeabaa-4936-11e8-976d-d326daa06ed2.gif)

### Cron notes 📓 

This PR removes the `minute` property from the cron job, since the original format of `minute '*/1'` is not compatible on all systems, such as AIX. This is OK because the `cron` cookbook sets `*` as the default for all [fields](https://github.com/chef-cookbooks/cron#properties).

### Validation of Work 👟 

This change has been tested on AIX 7.1; successfully upgrading from chef-client `12.22.3` to `14.0.202` by setting `node['chef_client_updater']['restart_chef_via_cron'] = true`
 
Afterwards, the temporary cron job starts the chef-client service back up as intended then, on the next converge, is removed from the cron entries. 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>