### PR TITLE
Move cron deletion to cleanup function of resource

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -198,6 +198,10 @@ def cleanup
       FileUtils.rm_rf chef_backup_dir
     end
   end
+  # When running under init this cron job is created after an update
+  cron 'chef_client_updater' do
+    action :delete
+  end unless platform_family?('windows')
 end
 
 def windows?

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,11 +17,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# When running under init this cron job is created after an update
-cron 'chef_client_updater' do
-  action :delete
-end unless platform_family?('windows')
-
 chef_client_updater 'update chef-client' do
   channel node['chef_client_updater']['channel']
   version node['chef_client_updater']['version']

--- a/test/cookbooks/test/attributes/default.rb
+++ b/test/cookbooks/test/attributes/default.rb
@@ -1,1 +1,1 @@
-default['chef_client_updater']['version'] = '13.6.0'
+default['chef_client_updater']['version'] = '13'


### PR DESCRIPTION
### Description

When I was running a wrapper cookbook using the chef_client_updater resource directly and not the default recipe, the cron job that is put in place during an upgrade never got deleted and chef-client was running every minute! 

To prevent this from happening, this pull request puts the cron job deletion code into the cleanup function of the resource so it gets run no matter the method you choose to use this cookbook.

I also updated the chef-client version in the test cookbook so the tests would run when I was trying to test these.

### Issues Resolved

No Issues that are already reported

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
