### PR TITLE
Do not attempt EventLog restart on Windows Server 2008

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -371,7 +371,10 @@ def execute_install_script(install_script)
             Destroy-OpenChefHandles
           }
 
-          Get-Service EventLog | Restart-Service -Force
+          $windows_kernel_version = (Get-WmiObject -class Win32_OperatingSystem).Version
+          if (-Not ($windows_kernel_version.Contains('6.0') -or $windows_kernel_version.Contains('6.1'))) {
+            Get-Service EventLog | Restart-Service -Force
+          }
 
           Remove-Item "#{chef_install_dir}" -Recurse -Force
 


### PR DESCRIPTION
### Description

The 3.3.4 version of this cookbook adds an EventLog service restart for Windows upgrades with the following line in `Chef_upgrade.ps1`:

```
Get-Service EventLog | Restart-Service -Force
```
However, on Windows Server 2008 editions, this is not possible for default functionality. The EventLog service has a dependency on the Task Scheduler service, which cannot be stopped/started/restarted with PowerShell. This bombs out the scheduled task that is to upgrade Chef-client and the system is left with a broken Chef-client installation. Simply skipping the EventLog restart on Windows Server 2008 systems mitigates this.

### Issues Resolved

None

### Check List

- [ X ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ X ] New functionality includes testing.
- [ X ] New functionality has been documented in the README if applicable
- [ X ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
