### PR TITLE
Attempt to move the chef install directory if it still exists before giving up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the chef_client_updater cookbook.
 
+## 3.3.6 (2018-07-23)
+
+- If the chef install directory still exists after being Remove-Item'ed, it is likely in a broken state with a locked file or two being present, and nothing else. Attempt to move it to another location to allow the updated version install to succeed.
+
 ## 3.3.5 (2018-06-20)
 
 - Do not attempt EventLog restart on Windows 7 or Windows Server 2008 editions.

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Upgrades chef-client to specified releases'
 long_description 'Upgrades chef-client to specified releases'
-version '3.3.5'
+version '3.3.6'
 
 chef_version '>= 11' if respond_to?(:chef_version)
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -214,6 +214,10 @@ def chef_backup_dir
   "#{chef_install_dir}.upgrade"
 end
 
+def chef_broken_dir
+  "#{chef_install_dir}.broken"
+end
+
 def chef_upgrade_log
   "#{chef_install_dir}_upgrade.log"
 end
@@ -400,6 +404,13 @@ def execute_install_script(install_script)
           }
 
           Remove-Item "#{chef_install_dir}" -Recurse -Force
+
+          if (test-path "#{chef_install_dir}") {
+            Write-Output "Removing #{chef_install_dir} did not completely succeed."
+            Write-Output "It is likely now in a bad state, not even usable as a backup."
+            Write-Output "Attempting to move #{chef_install_dir} to #{chef_broken_dir}"
+            Move-Item "#{chef_install_dir}" "#{chef_broken_dir}"
+          }
 
           if (test-path "#{chef_install_dir}") {
             Write-Output "#{chef_install_dir} still exists, upgrade will be aborted. Exiting (3)..."


### PR DESCRIPTION
### Description

If the chef install directory still exists after being Remove-Item'ed, it is likely in a broken state with a locked file or two being present, and nothing else. Attempt to move it to another location to allow the updated version install to succeed.

### Issues Resolved

This may relate to #112. The problem is chef-log.dll is locked in a way that the Handle tool was unable to clear, as a result the Remove-Item call prior to this new Move-Item call ends up removing almost everything, but leaves one file present which results in the new install not being able to work.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
