### PR TITLE
Allow for a configurable package install timeout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Installs the mixlib-install/mixlib-install gems and upgrades the chef-client.
 - `exec_args` - An array of arguments to exec the chef-client with. default: ARGV
 - `download_url_override` - The direct URL for the chef-client package.
 - `checksum` - The SHA-256 checksum of the chef-client package from the direct URL.
+- `install_timeout` - The install timeout for non-windows systems. The default is 600, slow machines may need to extend this.
 - `upgrade_delay` - The delay in seconds before the scheduled task to upgrade chef-client runs on windows. default: 61. Lowering this limit is not recommended.
 - `product_name` - The name of the product to upgrade. This can be `chef` or `chefdk` default: chef
 - `rubygems_url` - The location to source rubygems. Replaces the default https://www.rubygems.org.

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -438,7 +438,7 @@ def execute_install_script(install_script)
       action :nothing
     end.run_action(:run)
   else
-    upgrade_command = Mixlib::ShellOut.new(install_script, { timeout: new_resource.install_timeout } )
+    upgrade_command = Mixlib::ShellOut.new(install_script, timeout: new_resource.install_timeout)
     upgrade_command.run_command
     if upgrade_command.exitstatus != 0
       raise "Error updating chef-client. exit code: #{upgrade_command.exitstatus}.\nSTDERR: #{upgrade_command.stderr}\nSTDOUT: #{upgrade_command.stdout}"

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -438,7 +438,7 @@ def execute_install_script(install_script)
       action :nothing
     end.run_action(:run)
   else
-    upgrade_command = Mixlib::ShellOut.new(install_script, { :timeout => new_resource.install_timeout } )
+    upgrade_command = Mixlib::ShellOut.new(install_script, { timeout: new_resource.install_timeout } )
     upgrade_command.run_command
     if upgrade_command.exitstatus != 0
       raise "Error updating chef-client. exit code: #{upgrade_command.exitstatus}.\nSTDERR: #{upgrade_command.stderr}\nSTDOUT: #{upgrade_command.stdout}"

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -438,7 +438,7 @@ def execute_install_script(install_script)
       action :nothing
     end.run_action(:run)
   else
-    upgrade_command = Mixlib::ShellOut.new(install_script)
+    upgrade_command = Mixlib::ShellOut.new(install_script, { :timeout => new_resource.install_timeout } )
     upgrade_command.run_command
     if upgrade_command.exitstatus != 0
       raise "Error updating chef-client. exit code: #{upgrade_command.exitstatus}.\nSTDERR: #{upgrade_command.stderr}\nSTDOUT: #{upgrade_command.stdout}"

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -35,6 +35,9 @@ attribute :exec_command, kind_of: String, default: $PROGRAM_NAME.split(' ').firs
 attribute :exec_args, kind_of: Array, default: ARGV
 attribute :download_url_override, kind_of: String
 attribute :checksum, kind_of: String
+# If the package takes too long to install, mixlib-shellout will time out.
+# This enables users to adjust the timeout.
+attribute :install_timeout, kind_of: Integer, default: 600
 # If the upgrade is scheduled in the same minute that Chef runs,
 # there is a risk the upgrade will not be triggered.
 # Lowering upgrade_delay limit is not recommended.

--- a/test/cookbooks/test/recipes/default.rb
+++ b/test/cookbooks/test/recipes/default.rb
@@ -2,4 +2,5 @@ chef_client_updater "Install Chef #{node['chef_client_updater']['version']}" do
   channel 'stable'
   version node['chef_client_updater']['version']
   post_install_action 'exec'
+  install_timeout 599
 end


### PR DESCRIPTION
Signed-off-by: Joshua Justice <jjustice6@bloomberg.net>

### Description

Allow package install timeout to be configurable.

### Issues Resolved

On some machines and platforms, it is entirely possible for installing Chef to take more than 10 minutes, while working perfectly fine. We encountered this on some AIX machines in testing. This change would allow for 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
