### PR TITLE
Add cron to apt-get intermediate instruction to fix TravisCI tests

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -32,7 +32,7 @@ platforms:
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
-        - RUN /usr/bin/apt-get install sudo -y
+        - RUN /usr/bin/apt-get install sudo cron -y
 
 suites:
   - name: default

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
 
 matrix:
   include:
-    - rvm: 2.4.3
+    - rvm: 2.4.4
       before_script:
         - eval "$(chef shell-init bash)"
       install: echo "skip bundle install"
@@ -31,7 +31,7 @@ matrix:
         - cookstyle --version
         - foodcritic --version
         - chef exec delivery local all
-    - rvm: 2.4.3
+    - rvm: 2.4.4
       services: docker
       sudo: required
       before_script:
@@ -42,7 +42,7 @@ matrix:
       script:
         # this tests a downgrade from latest "13" to latest "12" via partial versions
         - bundle exec kitchen test constrained-ubuntu-1604
-    - rvm: 2.4.3
+    - rvm: 2.4.4
       services: docker
       sudo: required
       before_script:
@@ -52,7 +52,7 @@ matrix:
         - KITCHEN_YAML=.kitchen.dokken.yml
       script:
         - bundle exec kitchen test default-ubuntu-1604
-    - rvm: 2.4.3
+    - rvm: 2.4.4
       services: docker
       sudo: required
       before_script:
@@ -62,7 +62,7 @@ matrix:
         - KITCHEN_YAML=.kitchen.dokken.yml
       script:
         - bundle exec kitchen test default-ubuntu-1604
-    - rvm: 2.4.3
+    - rvm: 2.4.4
       services: docker
       sudo: required
       before_script:
@@ -72,7 +72,7 @@ matrix:
         - KITCHEN_YAML=.kitchen.dokken.yml
       script:
         - bundle exec kitchen test default-ubuntu-1604
-    - rvm: 2.4.3
+    - rvm: 2.4.4
       services: docker
       sudo: required
       before_script:

--- a/test/cookbooks/test/attributes/default.rb
+++ b/test/cookbooks/test/attributes/default.rb
@@ -1,1 +1,1 @@
-default['chef_client_updater']['version'] = '13'
+default['chef_client_updater']['version'] = '13.10.0'

--- a/test/cookbooks/test/recipes/constrained.rb
+++ b/test/cookbooks/test/recipes/constrained.rb
@@ -1,4 +1,4 @@
 chef_client_updater 'Install constrained version' do
-  version '12'
+  version '12.22.5'
   post_install_action 'exec'
 end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,5 +1,5 @@
 describe command('chef-client -v') do
-  target_version = ENV['OMNIBUS_CHEF_VERSION'] || '13.6.0'
+  target_version = '13.10.0'
   its('stdout') { should match "^Chef: #{target_version}" }
 end
 

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,5 +1,6 @@
 describe command('chef-client -v') do
-  its('stdout') { should match '^Chef: 13.6.0' }
+  target_version = ENV['OMNIBUS_CHEF_VERSION'] || '13.6.0'
+  its('stdout') { should match "^Chef: #{target_version}" }
 end
 
 describe command('/opt/chef/embedded/bin/gem -v') do


### PR DESCRIPTION
Signed-off-by: Stuart Preston <stuart@chef.io>

### Description

Testing addition of cron to dokken image via intermediate instruction

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
