### PR TITLE
fix update_rubygems rubygems_url code path with target_version

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -80,9 +80,9 @@ def update_rubygems
       raise 'cannot find omnibus install' unless ::File.exist?(gem_bin)
       source = "--clear-sources --source #{new_resource.rubygems_url}"
       if Gem::Requirement.new(nodoc_rubygems_versions).satisfied_by?(rubygems_version)
-        shell_out!("#{gem_bin} update --system --no-document #{source}")
+        shell_out!("#{gem_bin} update --system #{target_version} --no-document #{source}")
       else
-        shell_out!("#{gem_bin} update --system --no-rdoc --no-ri #{source}")
+        shell_out!("#{gem_bin} update --system #{target_version} --no-rdoc --no-ri #{source}")
       end
     else
       require 'rubygems/commands/update_command'


### PR DESCRIPTION
Signed-off-by: Ken MacLeod <ken.macleod@csgi.com>

### Description

This fix continues the fallout from the Rubygems 3.0 update.  The typical code path (I believe) is where `rubygems_url` is not set, when this code path is taken the Rubygems is pinned (to `target_version` = 2.6.11) and all seems to work fine because 2.6.11 works.  The code path where `rubygems_url` _is_ set isn't doing this pin and floats to latest 3.x, which still now hits another place where `--no-rdoc --no-ri`.  This PR adds the pin to the `rubygems_url` code path.

Due to comments in the Gemfile, I'm not sure if code tests are currently working with this cookbook.  I'm also not sure how I'd add a new test with the previous chef version installed.  I tested this by creating a EL7 kitchen instance, installing chef-12.21.3, then uploading and running `chef-client --local-mode` using a policy with this gem patched with this PR patch applied.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
