### PR TITLE
fix rubygems 3.0 again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,7 @@ matrix:
       before_install:
         # ancient ruby gets ancient bundler + ancient gem as well
         - bundle --version
+        - gem update --system 2.6.11
         - gem --version
       script:
         - bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,5 +86,9 @@ matrix:
         - bundle exec kitchen test default-ubuntu-1604
     - rvm: 1.9.3
       gemfile: gemfiles/Gemfile.ancient
+      before_install:
+        # ancient ruby gets ancient bundler + ancient gem as well
+        - bundle --version
+        - gem --version
       script:
         - bundle exec rspec

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -64,7 +64,7 @@ def update_rubygems
   nodoc_rubygems_versions = '>= 3.0'
 
   rubygems_version = Gem::Version.new(Gem::VERSION)
-  Chef::Log.debug("Found gem version #{rubygems_version}. Desired version is #{compatible_rubygems_version}")
+  Chef::Log.debug("Found gem version #{rubygems_version}. Desired version is #{compatible_rubygems_versions}")
   return if Gem::Requirement.new(compatible_rubygems_versions).satisfied_by?(rubygems_version)
 
   # only rubygems >= 1.5.2 supports pinning, and we might be coming from older versions

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -3,7 +3,7 @@
 # Resource:: updater
 #
 # Copyright:: 2016-2018, Will Jordan
-# Copyright:: 2016-2018, Chef Software Inc.
+# Copyright:: 2016-2019, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -60,11 +60,11 @@ end
 
 def update_rubygems
   compatible_rubygems_versions = '>= 2.6.11'
-  target_version = '2.6.11'
+  target_version = '2.7.8' # can be bumped to latest 2.x, but ruby < 2.3.0 support is necessary
   nodoc_rubygems_versions = '>= 3.0'
 
   rubygems_version = Gem::Version.new(Gem::VERSION)
-  Chef::Log.debug("Found gem version #{rubygems_version}. Desired version is at least #{target_version}")
+  Chef::Log.debug("Found gem version #{rubygems_version}. Desired version is #{compatible_rubygems_version}")
   return if Gem::Requirement.new(compatible_rubygems_versions).satisfied_by?(rubygems_version)
 
   # only rubygems >= 1.5.2 supports pinning, and we might be coming from older versions
@@ -80,9 +80,9 @@ def update_rubygems
       raise 'cannot find omnibus install' unless ::File.exist?(gem_bin)
       source = "--clear-sources --source #{new_resource.rubygems_url}"
       if Gem::Requirement.new(nodoc_rubygems_versions).satisfied_by?(rubygems_version)
-        shell_out!("#{gem_bin} update --system --no-document #{source}")
+        shell_out!("#{gem_bin} update --system #{target_version} --no-document #{source}")
       else
-        shell_out!("#{gem_bin} update --system --no-rdoc --no-ri #{source}")
+        shell_out!("#{gem_bin} update --system #{target_version} --no-rdoc --no-ri #{source}")
       end
     else
       require 'rubygems/commands/update_command'

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -60,7 +60,7 @@ end
 
 def update_rubygems
   compatible_rubygems_versions = '>= 2.6.11'
-  target_version = '2.7.8' # can be bumped to latest 2.x, but ruby < 2.3.0 support is necessary
+  target_version = '2.7.8' # should be bumped to latest 2.x, but ruby < 2.3.0 support is necessary
   nodoc_rubygems_versions = '>= 3.0'
 
   rubygems_version = Gem::Version.new(Gem::VERSION)


### PR DESCRIPTION
replaces #144 

when we fail the check on >= 2.6.11  we install 2.7.8 deliberately -- because if you've got super-old rubygems you are getting rudely force-upgraded anyway, and i want to skip over all the possible bugs between 2.6.11 and 2.7.8, which i find more likely than bugs in 2.7.8 on old systems at this point.  this also replicates the existing behavior -- up until it broke with rubygems 3.0 -- so this behavior is actually very well tested.

so the algorithm is:

- if you have >= 2.6.11 we leave it alone (and i don't entirely like this, but i haven't found a reason to force-upgrade these people.... yet...)
- if you have < 2.6.11 (which is all just totally broken) we force upgrade you to 2.7.8 which is the latest that we can get away with without rubygems 3.0 blowing up on very old ruby (which is what the cookbook did all along until rubygems 3.0 landed)