### PR TITLE
Add rubygems_url to default recipe

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -44,5 +44,8 @@ default['chef_client_updater']['upgrade_delay'] = nil
 # name of the product to upgrade (chef or chefdk)
 default['chef_client_updater']['product_name'] = nil
 
+# the location to source rubygems. Replaces the default https://www.rubygems.org.
+default['chef_client_updater']['rubygems_url'] = nil
+
 # download URL for Sysinternals handle.zip (Windows only)
 default['chef_client_updater']['handle_zip_download_url'] = nil

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,5 +26,6 @@ chef_client_updater 'update chef-client' do
   checksum node['chef_client_updater']['checksum'] if node['chef_client_updater']['checksum']
   upgrade_delay node['chef_client_updater']['upgrade_delay'] unless node['chef_client_updater']['upgrade_delay'].nil?
   product_name node['chef_client_updater']['product_name'] if node['chef_client_updater']['product_name']
+  rubygems_url default['chef_client_updater']['rubygems_url'] unless default['chef_client_updater']['rubygems_url'].nil?
   handle_zip_download_url node['chef_client_updater']['handle_zip_download_url'] if node['chef_client_updater']['handle_zip_download_url']
 end


### PR DESCRIPTION
Signed-off-by: Chris Forbes <kitforbes@users.noreply.github.com>

### Description

Adds an attribute for the `rubygems_url` and passes this through to the `chef_client_updater` in the `default` recipe.

### Issues Resolved

- #140 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
