### PR TITLE
Enable chef upgrade to install as scheduled task with install_command_options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of the chef_client_updater cookbook.
 
+## 3.8.0 (2019-11-27)
+
+- Add install_command_options to enable installing Chef as a scheduled task on Windows when updating
+- Fix Chef_upgrade scheduled task to reschedule itself when it fails due to running ruby.exe
+
 ## 3.7.3 (2019-12-09)
 
 - Minor Fixes While detecting chef DK version - [@Nimesh-Msys](https://github.com/Nimesh-Msys)

--- a/libraries/chef_client_updater_helper.rb
+++ b/libraries/chef_client_updater_helper.rb
@@ -1,0 +1,30 @@
+module ChefClientUpdaterHelper
+  def mixlib_install
+    load_mixlib_install
+    detected_platform = Mixlib::Install.detect_platform
+    Chef::Log.debug("Platform detected as #{detected_platform} by mixlib_install")
+    options = {
+      product_name: new_resource.product_name,
+      platform_version_compatibility_mode: true,
+      platform: detected_platform[:platform],
+      platform_version: detected_platform[:platform_version],
+      architecture: detected_platform[:architecture],
+      channel: new_resource.channel.to_sym,
+      product_version: new_resource.version == 'latest' ? :latest : new_resource.version,
+      install_command_options: new_resource.install_command_options,
+    }
+    options = add_download_url_override_options(options)
+
+    Chef::Log.debug("Passing options to mixlib-install: #{options}")
+    Mixlib::Install.new(options)
+  end
+
+  def add_download_url_override_options(options)
+    if new_resource.download_url_override
+      raise('Using download_url_override in the chef_client_updater resource requires also setting checksum property!') unless new_resource.checksum
+      Chef::Log.debug("Passing download_url_override of #{new_resource.download_url_override} and checksum of #{new_resource.checksum} to mixlib_install")
+      options[:install_command_options] = options[:install_command_options].merge(download_url_override: new_resource.download_url_override, checksum: new_resource.checksum)
+    end
+    options
+  end
+end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -46,3 +46,4 @@ attribute :product_name, kind_of: String, default: 'chef'
 attribute :rubygems_url, kind_of: String
 attribute :handle_zip_download_url, kind_of: String, default: 'https://download.sysinternals.com/files/Handle.zip'
 attribute :event_log_service_restart, kind_of: [TrueClass, FalseClass], default: true
+attribute :install_command_options, kind_of: Hash, default: {}

--- a/spec/unit/libraries/chef_client_updater_helper_spec.rb
+++ b/spec/unit/libraries/chef_client_updater_helper_spec.rb
@@ -1,0 +1,110 @@
+require 'spec_helper'
+require_relative '../../../libraries/chef_client_updater_helper'
+
+describe ChefClientUpdaterHelper do
+  let(:provider) { Object.new.extend(ChefClientUpdaterHelper) }
+  let(:product_name) { 'chef-client' }
+  let(:channel) { 'stable' }
+  let(:product_version) { 'latest' }
+  let(:install_command_options) { { option1: 'value1', option2: 'value2' } }
+  let(:download_url_override) { 'https://my-url' }
+  let(:checksum) { 12345 }
+  let(:resource) do
+    double('Chef::Resource::ChefClientUpdater',
+                          product_name: product_name, channel: channel, version: product_version, install_command_options: install_command_options,
+                          download_url_override: download_url_override, checksum: checksum)
+  end
+  let(:platform) { 'aix' }
+  let(:platform_version) { '4.5' }
+  let(:architecture) { 'x86' }
+  let(:detected_platform) { { platform: 'aix', platform_version: '4.5', architecture: 'x86' } }
+  let(:mixlib) { double('Mixlib::Install', new: true, detect_platform: detected_platform) }
+  let(:options) do
+    {
+      product_name: product_name,
+      platform_version_compatibility_mode: true,
+      platform: platform,
+      platform_version: platform_version,
+      architecture: architecture,
+      channel: channel.to_sym,
+      product_version: product_version.to_sym,
+      install_command_options: install_command_options,
+    }
+  end
+
+  before do
+    stub_const('::Mixlib::Install', mixlib)
+    allow(provider).to receive(:new_resource).and_return(resource)
+  end
+
+  describe '#mixlib_install' do
+    before do
+      allow(provider).to receive(:load_mixlib_install)
+      allow(Chef::Log).to receive(:debug).and_call_original
+      allow(Chef::Log).to receive(:debug).with('Platform detected as aix by mixlib_install')
+    end
+
+    it 'calls add_download_url_options with the expected options Hash' do
+      expect(provider).to receive(:add_download_url_override_options).with(options)
+      provider.mixlib_install
+    end
+
+    it 'calls Mixlib::Install.new with the correct options hash' do
+      allow(provider).to receive(:add_download_url_override_options).with(options).and_return(options)
+      expect(Mixlib::Install).to receive(:new).with(options)
+      provider.mixlib_install
+    end
+  end
+
+  describe '#add_download_url_override_options' do
+    # download_url_override nil default is never false so this is never true unless resource attribute is set to nil explicitly
+    context 'when download_url_override is false' do
+      before do
+        allow(resource).to receive(:download_url_override).and_return(false)
+      end
+
+      it 'never raises an error' do
+        expect { provider.add_download_url_override_options(options) }.to_not raise_error
+      end
+
+      it 'does not call new_resource.checksum' do
+        expect(resource).to_not receive(:checksum)
+        provider.add_download_url_override_options(options)
+      end
+
+      it 'does not add download url override key value pair' do
+        expect(provider.add_download_url_override_options(options)[:install_command_options].key?(:download_url_override)).to be false
+      end
+    end
+
+    context 'when new_resource.download_url_override is not false' do
+      # checksum nil default is never false so this is never true unless resource.checksum is set to nil explicitly
+      context 'when new_resource.checksum is false' do
+        before do
+          allow(resource).to receive(:checksum).and_return(false)
+        end
+
+        it 'raises an error that checksum must be set if download_url_override is set' do
+          expect { provider.add_download_url_override_options(options) }.to raise_error('Using download_url_override in the chef_client_updater resource requires also setting checksum property!')
+        end
+      end
+
+      context 'when new_resource.checksum is not false' do
+        it 'does not raise an error' do
+          expect { provider.add_download_url_override_options(options) }.not_to raise_error
+        end
+
+        it 'logs a debug message to Chef log' do
+          expect(Chef::Log).to receive(:debug).with("Passing download_url_override of #{download_url_override} and checksum of #{checksum} to mixlib_install")
+          provider.add_download_url_override_options(options)
+        end
+
+        it 'sets the options variable hash to include the download_url_override and checksum as key value pairs' do
+          provider.add_download_url_override_options(options)
+          expect(options[:install_command_options][:download_url_override]).to eq(download_url_override)
+          expect(options[:install_command_options][:checksum]).to eq(checksum)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add install_command_options to chef_client_updater resource for specifying additional command options when updating chef, such as installing as a scheduled task

Signed-off-by: George Holt <gholtiii@me.com>

### Description

The Chef_upgrade task previously would try only once to upgrade chef and would bail if ruby or opscode processes are still running, which is often the case on Windows platform.  The change enables the Chef_upgrade task to try 5 times, sleeping 60 seconds in between.  If it still fails it will reschedule itself 10 minutes in the future from the original task time, enabling it to continue trying to upgrade Chef until it succeeds.

It also adds the install_command_options property to the chef_client_updater, which is necessary to enable the resource to be used to install Chef as a scheduled task on Windows with the "daemon: 'task'" command line option.

### Issues Resolved

https://github.com/chef-cookbooks/chef_client_updater/issues/139
https://github.com/chef-cookbooks/chef_client_updater/issues/121

### Check List

- [ X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ X] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [ X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
