### PR TITLE
[MSYS-994] Add event_log_service_restart attribute to fix issue of non chef service restart

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -46,3 +46,6 @@ default['chef_client_updater']['product_name'] = nil
 
 # download URL for Sysinternals handle.zip (Windows only)
 default['chef_client_updater']['handle_zip_download_url'] = nil
+
+# The Eventlog service will be restarted immediately prior to cleanup broken chef to release any open file locks.
+default['chef_client_updater']['event_log_service_restart'] = true

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -62,6 +62,12 @@ suites:
     verifier:
       inspec_tests:
         - path: ./test/integration/default/
+  - name: no_service_restart
+    run_list:
+      - recipe[test::no_service_restart]
+    verifier:
+      inspec_tests:
+        - path: ./test/integration/default/
   - name: direct_url
     run_list:
       - recipe[test::direct_url]

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -27,4 +27,5 @@ chef_client_updater 'update chef-client' do
   upgrade_delay node['chef_client_updater']['upgrade_delay'] unless node['chef_client_updater']['upgrade_delay'].nil?
   product_name node['chef_client_updater']['product_name'] if node['chef_client_updater']['product_name']
   handle_zip_download_url node['chef_client_updater']['handle_zip_download_url'] if node['chef_client_updater']['handle_zip_download_url']
+  event_log_service_restart node['chef_client_updater']['event_log_service_restart']
 end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -45,3 +45,4 @@ attribute :upgrade_delay, kind_of: Integer, default: 60
 attribute :product_name, kind_of: String, default: 'chef'
 attribute :rubygems_url, kind_of: String
 attribute :handle_zip_download_url, kind_of: String, default: 'https://download.sysinternals.com/files/Handle.zip'
+attribute :event_log_service_restart, kind_of: [TrueClass, FalseClass], default: true

--- a/test/cookbooks/test/recipes/no_service_restart.rb
+++ b/test/cookbooks/test/recipes/no_service_restart.rb
@@ -1,0 +1,6 @@
+chef_client_updater "Install Chef #{node['chef_client_updater']['version']}" do
+  channel 'stable'
+  version node['chef_client_updater']['version']
+  event_log_service_restart false
+  post_install_action 'kill'
+end


### PR DESCRIPTION
### Description
 Added attribute `event_log_service_restart ` to restart EventLog service which will give authority for user to restart the service or not.

Which will resolves issue of  "chef_client_updater kills non chef processes on windows during upgrades" and #74 

### Issues Resolved

Backstory #117 


### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
