### PR TITLE
Allow path to handle.exe to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Installs the mixlib-install/mixlib-install gems and upgrades the chef-client.
 - `upgrade_delay` - The delay in seconds before the scheduled task to upgrade chef-client runs on windows. default: 61. Lowering this limit is not recommended.
 - `product_name` - The name of the product to upgrade. This can be `chef` or `chefdk` default: chef
 - `rubygems_url` - The location to source rubygems. Replaces the default https://www.rubygems.org.
-- `handle_zip_download_url` - Url to the Handle zip archive used by Windows. Used to override the default in airgapped environments. default: https://download.sysinternals.com/files/Handle.zip
+- `handle_zip_download_url` - Url to the Handle zip archive used by Windows. Used to override the default in airgapped environments. default: https://download.sysinternals.com/files/Handle.zip (Note that you can also override the `default['chef_client_updater']['handle_exe_path']` attribute if you already have that binary somewhere on your system)
 
 #### examples
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -46,6 +46,7 @@ default['chef_client_updater']['product_name'] = nil
 
 # download URL for Sysinternals handle.zip (Windows only)
 default['chef_client_updater']['handle_zip_download_url'] = nil
+default['chef_client_updater']['handle_exe_path'] = "#{Chef::Config[:file_cache_path]}/handle.exe"
 
 # The Eventlog service will be restarted immediately prior to cleanup broken chef to release any open file locks.
 default['chef_client_updater']['event_log_service_restart'] = true


### PR DESCRIPTION
Signed-off-by: Stefan Wessels Beljaars <swesselsbeljaars@schubergphilis.com>

### Description

Allow path to handle.exe to be configured. This is useful if you already have handle.exe somewhere else on your system.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
