### PR TITLE
Update default_spec.rb

### DIFF
--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -1,6 +1,6 @@
 describe command('chef-client -v') do
-  target_version = '13.10.0'
-  its('stdout') { should match "^Chef: #{target_version}" }
+  target_version = ['chef_client_updater']['version']
+  its('stdout') { should match "^(Chef: \d+\.)(\d+\.)(\d+)|(Chef Infra Client: \d+\.)(\d+\.)(\d+)" }
 end
 
 describe command('/opt/chef/embedded/bin/gem -v') do


### PR DESCRIPTION
This should allow for the test to verify that the version specified in the attributes or wrappers is checked.  It will also check it is either the chef client or the chef infra client.

### Description
This makes the test for the cookbook viable for use by a wrapper.
[Describe what this change achieves]

### Issues Resolved
#155 
[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
