### PR TITLE
Fix creation of cron error while licence acceptance

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -507,7 +507,7 @@ action :update do
                     '/etc/init.d/chef-client start'
                   end
       unless node['chef_client']['chef_license'].nil?
-        start_cmd = "env CHEF_LICENSE=\"#{node['chef_client']['chef_license']}\"\n" + start_cmd
+        start_cmd = "env CHEF_LICENSE=\"#{node['chef_client']['chef_license']}\" " + start_cmd
       end
 
       r = cron 'chef_client_updater' do


### PR DESCRIPTION
Signed-off-by: NAshwini <ashwini.nehate@msystechnologies.com>

### Description

While creating cronjob for licence acceptance gets below error:
<details>
[root@ashrhel6 ~]# [2019-09-27T04:49:33-04:00] WARN: Chef Client was upgraded, scheduling chef-client start via cron in 5 minutes

    * cron[chef_client_updater] action createKilled
[root@ashrhel6 ~]#

      ================================================================================
      Error executing action `create` on resource 'cron[chef_client_updater]'
      ================================================================================

      Chef::Exceptions::Cron
      ----------------------
      Error updating state of chef_client_updater, error: Expected process to exit with [0], but received '1'
      ---- Begin output of crontab -u root - ----
      STDOUT:
      STDERR: "-":3: bad minute
      errors in crontab file, can't install.
      ---- End output of crontab -u root - ----
      Ran crontab -u root - returned 1

      Cookbook Trace:
      ---------------
      /var/chef/cache/cookbooks/chef_client_updater/providers/default.rb:519:in `rescue in block in class_from_file'
      /var/chef/cache/cookbooks/chef_client_updater/providers/default.rb:479:in `block in class_from_file'

      Resource Declaration:
      ---------------------
      # In /var/chef/cache/cookbooks/chef_client_updater/providers/default.rb

      513:       r = cron 'chef_client_updater' do
      514:         hour cron_time.hour
      515:         minute cron_time.min
      516:         command start_cmd
      517:       end
      518:

      Compiled Resource:
      ------------------
      # Declared in /var/chef/cache/cookbooks/chef_client_updater/providers/default.rb:513:in `rescue in block in class_from_file'

      cron("chef_client_updater") do
        action [:create]
        default_guard_interpreter :default
        minute "54"
        hour "4"
        day "*"
        month "*"
        weekday "*"
        command "env CHEF_LICENSE=\"accept\"\n/etc/init.d/chef-client start"
        user "root"
        declared_type :cron
        cookbook_name "chef_client_updater"
      end

      System Info:
      ------------
      chef_version=13.9.4
      platform=redhat
      platform_version=6.10
      ruby=ruby 2.4.4p296 (2018-03-28 revision 63013) [x86_64-linux]
      program_name=chef-client worker: ppid=98531;start=04:49:14;
      executable=/opt/chef/bin/chef-client
</details>

### Issues Resolved

 https://github.com/chef-cookbooks/chef_client_updater/issues/157

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
