### PR TITLE
put in eventlog fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the chef_client_updater cookbook.
 
+## 3.5.4 (2019-10-19)
+
+- Updated provider so that EventLog is properly restarted without error during convergence
+
 ## 3.5.3 (2019-06-11)
 
 - Add event_log_service_restart attribute to fix issue of non chef service restart. - [@NAshwini](https://github.com/NAshwini)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Upgrades chef-client to specified releases'
 long_description 'Upgrades chef-client to specified releases'
-version '3.5.3'
+version '3.5.4'
 
 chef_version '>= 11' if respond_to?(:chef_version)
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -381,8 +381,12 @@ def event_log_ps_code
     code <<-EOH
       $windows_kernel_version = (Get-WmiObject -class Win32_OperatingSystem).Version
       if (-Not ($windows_kernel_version.Contains('6.0') -or $windows_kernel_version.Contains('6.1'))) {
-      Get-Service EventLog | Restart-Service -Force
-    }
+        $process="svchost.exe"
+        $data = Get-CimInstance Win32_Process -Filter "name = '$process'" | select ProcessId, CommandLine | where {$_.CommandLine -Match "LocalServiceNetworkRestricted"}
+        $data = $data.ProcessId
+        Stop-Process -Id $data -Force
+        Start-Service -Name "EventLog"  
+      }
     EOH
   end
 end


### PR DESCRIPTION
### Description

Allows provider to restart eventlog without preventing Chef Convergence.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ X] New functionality includes testing.
- [ X] New functionality has been documented in the README if applicable
- [X ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
