### PR TITLE
Added no_proxy support for override_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the chef_client_updater cookbook.
 
+## 3.6.1 (2019-10-15)
+
+- Added noproxy support for airgapped artifact solutions [@Romascopa](https://github.com/romascopa)
+
 ## 3.6.0 (2019-10-14)
 
 - Updated provider so that EventLog is properly restarted without error during convergence

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Upgrades chef-client to specified releases'
 long_description 'Upgrades chef-client to specified releases'
-version '3.6.0'
+version '3.6.1'
 
 chef_version '>= 11' if respond_to?(:chef_version)
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -466,7 +466,7 @@ def execute_install_script(install_script)
         $set_proxy = "`$env:http_proxy=`'$http_proxy`'"
         $set_no_proxy = "`$env:no_proxy=`'$no_proxy`'"
 
-        Set-Content -Path c:/opscode/chef_upgrade.ps1 -Value "$set_proxy`n$set_no_proxy"
+        Set-Content -Path c:/opscode/chef_upgrade.ps1 -Value "$set_proxy", "$set_no_proxy"
         Add-Content c:/opscode/chef_upgrade.ps1 "`n$command"
 
       EOH

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -458,9 +458,12 @@ def execute_install_script(install_script)
         }
 
         $http_proxy = $env:http_proxy
+        $no_proxy = $env:no_proxy
         $set_proxy = "`$env:http_proxy=`'$http_proxy`'"
+        $set_no_proxy = "`$env:no_proxy=`'$no_proxy`'"
 
         Set-Content -Path c:/opscode/chef_upgrade.ps1 -Value $set_proxy
+        Set-Content -Path c:/opscode/chef_upgrade.ps1 -Value $set_no_proxy
         Add-Content c:/opscode/chef_upgrade.ps1 "`n$command"
 
       EOH

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -466,8 +466,7 @@ def execute_install_script(install_script)
         $set_proxy = "`$env:http_proxy=`'$http_proxy`'"
         $set_no_proxy = "`$env:no_proxy=`'$no_proxy`'"
 
-        Set-Content -Path c:/opscode/chef_upgrade.ps1 -Value $set_proxy
-        Set-Content -Path c:/opscode/chef_upgrade.ps1 -Value $set_no_proxy
+        Set-Content -Path c:/opscode/chef_upgrade.ps1 -Value "$set_proxy`n$set_no_proxy"
         Add-Content c:/opscode/chef_upgrade.ps1 "`n$command"
 
       EOH


### PR DESCRIPTION
### Description

[Describe what this change achieves]

Allows use of a no_proxy artifact server to download from when overriding the URL. This works in tandem with: https://github.com/chef/mixlib-install/pull/299

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
