### PR TITLE
Allowing custom rubygems server

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -55,3 +55,9 @@ default['chef_client_updater']['event_log_service_restart'] = true
 # in a backwards compatible way. Use the same attribute from the chef-client cookbook to
 # avoid duplication.
 default['chef_client']['chef_license'] = nil
+
+# Set this to use internal or custom rubygems server.
+# Use the same attribute from the chef-client cookbook to avoid duplication.
+# Example "http://localhost:8808/"
+#
+default['chef_client']['config']['rubygems_url'] = nil

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,4 +28,5 @@ chef_client_updater 'update chef-client' do
   product_name node['chef_client_updater']['product_name'] if node['chef_client_updater']['product_name']
   handle_zip_download_url node['chef_client_updater']['handle_zip_download_url'] if node['chef_client_updater']['handle_zip_download_url']
   event_log_service_restart node['chef_client_updater']['event_log_service_restart']
+  rubygems_url node['chef_client']['config']['rubygems_url'] if node['chef_client']['config']['rubygems_url']
 end


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

### Description

- Sets custom rubygems server which can work when cookbook is being used in air-gapped environment.
- Earlier it was being set to `rubygems.org` by default because of `nil` for `new_resource.rubygems_url` here https://github.com/chef-cookbooks/chef_client_updater/blob/master/providers/default.rb#L34 and causes failure when cookbook is used in an air-gapped environment 
- Test cases/recipes are already written to set `rubygems_url`
### Issues Resolved

Fixes https://getchef.zendesk.com/agent/tickets/20046

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
