### PR TITLE
Minor Fixes While detecting chef DK version

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -138,8 +138,10 @@ def current_version
   when 'chefdk'
     versions = Mixlib::ShellOut.new('chef -v').run_command.stdout
     # There is a verbiage change in newer version of Chef Infra
-    version = versions.match(/^ChefDK Version.*/i) || versions.match(/^Chef Development Kit Version.*/i)
-    version ? version.to_s.split(': ').last&.strip : nil
+    version = versions.match(/(ChefDK Version(.)*:)\s*([\d.]+)/i) || versions.match(/(Chef Development Kit Version(.)*:)\s*([\d.]+)/i)
+    if version
+      version = version[-1].to_s.strip
+    end
   end
 end
 


### PR DESCRIPTION
- Fixes compilation error while upgrading from Chef-12
- Better regex to identify correct ChefDK version: Detecting version within the line

### Description

Previous [PR#167](https://github.com/chef-cookbooks/chef_client_updater/pull/167) had some issues related to upgrading from Chef-12. This code avoids using safe navigation operator.

### Issues Resolved

#170 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
