### PR TITLE
Fix Windows Upgrade scheduled task

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -119,9 +119,8 @@ def current_version
     versions = Mixlib::ShellOut.new('chef -v').run_command.stdout
     # There is a verbiage change in newer version of Chef Infra
     version = versions.match(/(ChefDK Version(.)*:)\s*([\d.]+)/i) || versions.match(/(Chef Development Kit Version(.)*:)\s*([\d.]+)/i)
-    if version
-      version = version[-1].to_s.strip
-    end
+
+    return version[-1].to_s.strip if version
   end
 end
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -335,9 +335,9 @@ def wait_for_chef_client_or_reschedule_upgrade_task_function
     <# Wait for running chef-client to finish up to n times.  If it has not finished after maxcount tries, then reschedule the upgrade task inMinutes minutes in the future and exit.
     #>
     param(
-          [Parameter(Mandatory=$true)]
+          [Parameter(Mandatory=$false)]
           [Int]$maxcount = 5,
-          [Parameter(Mandatory=$true)]
+          [Parameter(Mandatory=$false)]
           [Int]$inMinutes = 10
     )
 


### PR DESCRIPTION
### Description

Fix Windows scheduled task by removing mandatory parameters for WaitForChefClientOrRescheduleUpgradeTask

We call the function bare, so a prompt to supply the input parameters occurs as described by @cdbeard2016 in #172 

https://github.com/chef-cookbooks/chef_client_updater/blob/a27cff51897b9d0a49315b9da8381936312b33e7/providers/default.rb#L482

### Issues Resolved

https://github.com/chef-cookbooks/chef_client_updater/issues/172

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
