### PR TITLE
Removed rubygems_url attribute and updated rubygems_url resource

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -60,4 +60,3 @@ default['chef_client']['chef_license'] = nil
 # Use the same attribute from the chef-client cookbook to avoid duplication.
 # Example "http://localhost:8808/"
 #
-default['chef_client']['config']['rubygems_url'] = nil

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -43,7 +43,7 @@ attribute :install_timeout, kind_of: Integer, default: 600
 # Lowering upgrade_delay limit is not recommended.
 attribute :upgrade_delay, kind_of: Integer, default: 60
 attribute :product_name, kind_of: String, default: 'chef'
-attribute :rubygems_url, kind_of: String, default: lazy { Chef::Config[:rubygems_url] }
+attribute :rubygems_url, kind_of: Symbol, default: lazy { Chef::Config[:rubygems_url] }
 attribute :handle_zip_download_url, kind_of: String, default: 'https://download.sysinternals.com/files/Handle.zip'
 attribute :event_log_service_restart, kind_of: [TrueClass, FalseClass], default: true
 attribute :install_command_options, kind_of: Hash, default: {}

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -43,7 +43,7 @@ attribute :install_timeout, kind_of: Integer, default: 600
 # Lowering upgrade_delay limit is not recommended.
 attribute :upgrade_delay, kind_of: Integer, default: 60
 attribute :product_name, kind_of: String, default: 'chef'
-attribute :rubygems_url, kind_of: String
+attribute :rubygems_url, kind_of: String, default: lazy { Chef::Config[:rubygems_url] }
 attribute :handle_zip_download_url, kind_of: String, default: 'https://download.sysinternals.com/files/Handle.zip'
 attribute :event_log_service_restart, kind_of: [TrueClass, FalseClass], default: true
 attribute :install_command_options, kind_of: Hash, default: {}


### PR DESCRIPTION
### Description

Updated the `:rubygems_url` resource to set a default value and removed the `['chef_client]['config']['rubygems_url']` attribute from `attributes/default.rb`. Let me know if something needs to be changed with this

### Issues Resolved

https://github.com/chef-cookbooks/chef_client_updater/issues/176

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
