### PR TITLE
Fix `nil:NilClass error` arising due to removal of attribute `rubygems_url` 

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,4 +59,4 @@ default['chef_client']['chef_license'] = nil
 # Set this to use internal or custom rubygems server.
 # Use the same attribute from the chef-client cookbook to avoid duplication.
 # Example "http://localhost:8808/"
-default['chef_client_updater']['rubygems_url'] = "#{Chef::Config[:rubygems_url]}"
+default['chef_client_updater']['rubygems_url'] = (Chef::Config[:rubygems_url]).to_s

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,4 +59,4 @@ default['chef_client']['chef_license'] = nil
 # Set this to use internal or custom rubygems server.
 # Use the same attribute from the chef-client cookbook to avoid duplication.
 # Example "http://localhost:8808/"
-#
+default['chef_client_updater']['rubygems_url'] = "#{Chef::Config[:rubygems_url]}"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,5 +28,5 @@ chef_client_updater 'update chef-client' do
   product_name node['chef_client_updater']['product_name'] if node['chef_client_updater']['product_name']
   handle_zip_download_url node['chef_client_updater']['handle_zip_download_url'] if node['chef_client_updater']['handle_zip_download_url']
   event_log_service_restart node['chef_client_updater']['event_log_service_restart']
-  rubygems_url node['chef_client']['config']['rubygems_url'] if node['chef_client']['config']['rubygems_url']
+  rubygems_url node['chef_client_updater']['rubygems_url'] if node['chef_client_updater']['rubygems_url']
 end


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

### Description

- Originally attribute `default['chef_client']['config']['rubygems_url']` was added to support mirror/internal rubygems server( But was not honoring the namespacing rules and got merged).
-  Based on https://github.com/chef-cookbooks/chef_client_updater/issues/176#issuecomment-583184795 PR https://github.com/chef-cookbooks/chef_client_updater/pull/180 is created and did not delete the attribute from recipe.
- So this caused `nil:NilClass error` arising from recipe.
- Changed the attribute name to `default['chef_client_updater']['rubygems_url']` in order to support internal rubygems server as well as meeting namespacing rules of the cookbook.
- Comments for reference https://github.com/chef-cookbooks/chef_client_updater/pull/180#issuecomment-592380300 

### Issues Resolved

https://getchef.zendesk.com/agent/tickets/24503

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
