### PR TITLE
Fixed restart eventlog and dependent services

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -436,11 +436,12 @@ def event_log_ps_code
     code <<-EOH
       $windows_kernel_version = (Get-WmiObject -class Win32_OperatingSystem).Version
       if (-Not ($windows_kernel_version.Contains('6.0') -or $windows_kernel_version.Contains('6.1'))) {
-        $process="svchost.exe"
-        $data = Get-CimInstance Win32_Process -Filter "name = '$process'" | select ProcessId, CommandLine | where {$_.CommandLine -Match "LocalServiceNetworkRestricted"}
-        $data = $data.ProcessId
-        Stop-Process -Id $data -Force
-        Start-Service -Name "EventLog"
+        $dependentActiveServices = (Get-Service EventLog).DependentServices | Where-Object {$_.Status -eq "Running"}
+        Stop-Service -Name "EventLog" -Force
+        Start-Service -Name $dependentActiveServices.Name
+        if((Get-Service EventLog).Status -ne 'Stopped' ){
+          Start-Service -Name "EventLog"
+        }
       }
     EOH
   end


### PR DESCRIPTION
Signed-off-by: sanga17 <sausekar@msystechnologies.com>

### Description

Eventlog restart should also restart dependent services previously stopped

### Issues Resolved

Fixes: https://github.com/chef-cookbooks/chef_client_updater/issues/179

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
