### PR TITLE
Update the kitchen config with win2k19 and additional memory

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -30,6 +30,8 @@ platforms:
   - name: windows-2012r2
     driver:
       box: tas50/windows_2012r2
+      customize:
+        memory: 4096
     provisioner:
       wait_for_retry: 300
     transport:
@@ -38,6 +40,18 @@ platforms:
   - name: windows-2016
     driver:
       box: tas50/windows_2016
+      customize:
+        memory: 4096
+    provisioner:
+      wait_for_retry: 300
+    transport:
+      name: winrm
+      elevated: true
+  - name: windows-2019
+    driver:
+      box: tas50/windows_2019
+      customize:
+        memory: 4096
     provisioner:
       wait_for_retry: 300
     transport:
@@ -46,9 +60,8 @@ platforms:
   - name: macos-10.15
     driver:
       box: tas50/macos_10.15
-  - name: sles-12-sp1
-    driver:
-      box: chef/sles-12-sp1-x86_64 # private box in Chef's Atlas account
+      customize:
+        memory: 4096
 
 suites:
   - name: default
@@ -57,6 +70,7 @@ suites:
     excludes:
       - windows-2012r2
       - windows-2016
+      - windows-2019
   - name: license
     run_list:
       - recipe[test::license]


### PR DESCRIPTION
Make sure we can run the tests without low memory errors from Windows.

Signed-off-by: Tim Smith <tsmith@chef.io>