### PR TITLE
Catch when the windows upgrades fail

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -549,7 +549,6 @@ def execute_install_script(install_script)
             Write-Output "An error occured while trying to install product"
             Write-Output $_
 
-            # Should we move the backup directory back?
             # Might need more testing about different ways the installation could fail
             Move-Item "#{chef_backup_dir}" "#{chef_install_dir}"
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -306,7 +306,7 @@ def prepare_windows
     not_if { ::File.file?(node['chef_client_updater']['handle_exe_path']) }
   end.run_action(:create)
 
-  Kernel.spawn("c:/windows/system32/schtasks.exe /F /RU SYSTEM /create /sc once /ST \"#{upgrade_start_time}\" /tn Chef_upgrade /tr \"powershell.exe -ExecutionPolicy Bypass \"#{chef_install_dir}\"/../chef_upgrade.ps1 > #{chef_upgrade_log}\"")
+  Kernel.spawn("c:/windows/system32/schtasks.exe /F /RU SYSTEM /create /sc once /ST \"#{upgrade_start_time}\" /tn Chef_upgrade /tr \"powershell.exe -ExecutionPolicy Bypass \"#{chef_install_dir}\"/../chef_upgrade.ps1 2>&1 > #{chef_upgrade_log}\"")
   FileUtils.rm_rf "#{chef_install_dir}/bin/chef-client.bat"
 end
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -329,7 +329,7 @@ def uninstall_ps_code
       $installed_product = (get-item HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Installer\\UpgradeCodes\\C58A706DAFDB80F438DEE2BCD4DCB65C).Property
       $msi_guid = guid_from_regvalue $installed_product
 
-      echo "Removing installed product {$msi_guid}"
+      Write-Output "Removing installed product {$msi_guid}"
       Start-Process msiexec.exe -Wait -ArgumentList "/x {$msi_guid} /q"
     }
 
@@ -503,7 +503,7 @@ def execute_install_script(install_script)
       code <<-EOH
         $command = {
           $timestamp = Get-Date
-          echo "Starting upgrade at $timestamp"
+          Write-Output "Starting upgrade at $timestamp"
 
           Get-Service chef-client -ErrorAction SilentlyContinue | stop-service
           Get-Service push-jobs-client -ErrorAction SilentlyContinue | stop-service
@@ -538,10 +538,10 @@ def execute_install_script(install_script)
             exit 3
           }
 
-          echo "Attempting to uninstall product"
+          Write-Output "Attempting to uninstall product"
           #{uninstall_first}
 
-          echo "Running product install script..."
+          Write-Output "Running product install script..."
           try {
             #{install_script}
           }
@@ -555,7 +555,7 @@ def execute_install_script(install_script)
 
             exit 100
           }
-          echo "Install script finished"
+          Write-Output "Install script finished"
 
           Remove-Item "#{chef_install_dir}/../chef_upgrade.ps1"
           c:/windows/system32/schtasks.exe /delete /f /tn Chef_upgrade
@@ -584,7 +584,7 @@ def execute_install_script(install_script)
           Get-Service push-jobs-client -ErrorAction SilentlyContinue | start-service
 
           $timestamp = Get-Date
-          echo "Finished upgrade at $timestamp"
+          Write-Output "Finished upgrade at $timestamp"
         }
 
         $http_proxy = $env:http_proxy


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

### Description
<!--- Describe what this change achieves -->
This adds a catch block around the mixlib-install scripts to handle any
exceptions that are thrown. Along with some additional messages so we
know what's currently happening

Also, moves the handle.zip install to earlier in the process so it can fail
before we remove the chef directory.

### Issues Resolved
<!--- List any existing issues this PR resolves -->

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>