### PR TITLE
Fix license acceptance on non-windows

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -636,8 +636,10 @@ action :update do
                   else
                     '/etc/init.d/chef-client start'
                   end
+      env = {}
       unless node['chef_client']['chef_license'].nil?
-        start_cmd = "env CHEF_LICENSE=\"#{node['chef_client']['chef_license']}\" " + start_cmd
+        env['CHEF_LICENSE'] = node['chef_client']['chef_license']
+        fork { Kernel.exec(env, 'chef-client', '-z') }
       end
 
       r = cron 'chef_client_updater' do

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -637,9 +637,8 @@ action :update do
                     '/etc/init.d/chef-client start'
                   end
       unless node['chef_client']['chef_license'].nil?
-        env = {}
-        env['CHEF_LICENSE'] = node['chef_client']['chef_license']
-        fork { Kernel.exec(env, "#{chef_install_dir}/bin/chef-apply", '-e "exit 0"') }
+        license_acceptance = shell_out("#{chef_install_dir}/bin/chef-apply -e 'exit 0'", timeout: 60, environment: { 'CHEF_LICENSE' => "#{node['chef_client']['chef_license']}" })
+        Chef::Log.warn 'Something went wrong while accepting the license.' if license_acceptance.exitstatus != 0
       end
 
       r = cron 'chef_client_updater' do

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -639,7 +639,7 @@ action :update do
       unless node['chef_client']['chef_license'].nil?
         env = {}
         env['CHEF_LICENSE'] = node['chef_client']['chef_license']
-        fork { Kernel.exec(env, 'chef-client', '-z') }
+        fork { Kernel.exec(env, "#{chef_install_dir}/bin/chef-apply", '-e "exit 0"') }
       end
 
       r = cron 'chef_client_updater' do

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -638,7 +638,7 @@ action :update do
                   end
       unless node['chef_client']['chef_license'].nil?
         license_acceptance = shell_out("#{chef_install_dir}/bin/chef-apply -e 'exit 0'", timeout: 60, environment: { 'CHEF_LICENSE' => "#{node['chef_client']['chef_license']}" })
-        Chef::Log.warn 'Something went wrong while accepting the license.' if license_acceptance.exitstatus != 0
+        Chef::Log.warn 'Something went wrong while accepting the license.' if license_acceptance.error?
       end
 
       r = cron 'chef_client_updater' do

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -636,8 +636,8 @@ action :update do
                   else
                     '/etc/init.d/chef-client start'
                   end
-      env = {}
       unless node['chef_client']['chef_license'].nil?
+        env = {}
         env['CHEF_LICENSE'] = node['chef_client']['chef_license']
         fork { Kernel.exec(env, 'chef-client', '-z') }
       end


### PR DESCRIPTION
Signed-off-by: dheerajd-msys <dheeraj.dubey@msystechnologies.com>

<!--- Provide a short summary of your changes in the Title above -->
This change upgrades the client on non-windows node as well as handles the license acceptance issue specific to when upgrade is done from v13 to v15
### Description
<!--- Describe what this change achieves -->
-- Setting the attribute `default['chef_client']['chef_license'] = 'accept'` was not working when it was done from `chef v13` to `chef v15`. So this change handles this behaviour and works well on non-windows node.
-- Tested on centos and ubuntu
### Issues Resolved
<!--- List any existing issues this PR resolves -->
Fixes https://github.com/chef-cookbooks/chef_client_updater/issues/203

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>