### PR TITLE
Relocate License Logic on Windows systems into Ruby 

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -496,13 +496,15 @@ def execute_install_script(install_script)
                         ''
                       end
 
-    post_action = if new_resource.post_install_action == 'exec'
+                      license_provided = node['chef_client']['chef_license'] || ''
+
+    post_action = if (new_resource.post_install_action == 'exec') && (desired_version.major >= 15)
+                    "#{new_resource.exec_command} --chef-license #{license_provided}"
+                  elsif desired_version < '15'
                     new_resource.exec_command
                   else
                     ''
                   end
-
-    license_provided = node['chef_client']['chef_license'] || ''
 
     powershell_script 'Chef Infra Client Upgrade Script' do
       code <<-EOH
@@ -563,25 +565,6 @@ def execute_install_script(install_script)
 
           Remove-Item "#{chef_install_dir}/../chef_upgrade.ps1"
           c:/windows/system32/schtasks.exe /delete /f /tn Chef_upgrade
-
-          if ('#{desired_version}' -ge '15') {
-
-            SET CHEF_LICENSE '#{license_provided}'
-
-            #{chef_install_dir}/embedded/bin/ruby.exe -e "
-              begin
-                require 'chef/VERSION'
-                require 'license_acceptance/acceptor'
-                acceptor = LicenseAcceptance::Acceptor.new(provided: '#{license_provided}')
-                if acceptor.license_required?('chef', Chef::VERSION)
-                  license_id = acceptor.id_from_mixlib('chef')
-                  acceptor.check_and_persist(license_id, Chef::VERSION)
-                end
-              rescue LoadError
-                puts 'License acceptance might not be needed !'
-              end
-            "
-          }
 
           #{post_action}
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -500,7 +500,7 @@ def execute_install_script(install_script)
 
     post_action = if (new_resource.post_install_action == 'exec') && (desired_version.major >= 15)
                     "#{new_resource.exec_command} --chef-license #{license_provided}"
-                  elsif desired_version < '15'
+                  elsif desired_version.major < '15'
                     new_resource.exec_command
                   else
                     ''


### PR DESCRIPTION
Previous logic used PowerShell to call ruby.exe, with the ruby being an embedded string within the PowerShell script. That ruby used LicenseAcceptance::Acceptor to apply the license acceptance condition. This also used chef_install_dir to determine where Chef was located.

The new logic eliminates the embedded Ruby by determining if there is license acceptance before starting PowerShell to modify the command line of the post-action ChefClient execution. This now will use the --chef-license command line parameter to affect the license state. Instead of using chef_install_dir to determine where Chef is installed it will use the exec_command resource.

### Description
There are two desired impacts of this change 

1) Stylistically it is poor form to embed Ruby in PowerShell that is effectively called by Ruby. If there were tests for this code, it would be untestable. 

2) The use of chef_install_dir is used for two non-congruent purposes in the cookbook:
   -- determines the directory where the PowerShell script to be run is located. 
[https://github.com/chef-cookbooks/chef_client_updater/blob/a7093078a69b3dad593a46eab59349e9c323d392/providers/default.rb#L309](https://github.com/chef-cookbooks/chef_client_updater/blob/a7093078a69b3dad593a46eab59349e9c323d392/providers/default.rb#L309)
That location would (by default) be C:\OpsCode. 

   -- determines where ruby.exe is located (in PowerShell).
[https://github.com/chef-cookbooks/chef_client_updater/blob/a7093078a69b3dad593a46eab59349e9c323d392/providers/default.rb#L571](https://github.com/chef-cookbooks/chef_client_updater/blob/a7093078a69b3dad593a46eab59349e9c323d392/providers/default.rb#L571
)
The need this addresses is to allow the PowerShell script to be run from a directory other than that in which Chef is installed. This is a security requirement for us. While the more obvious change may have been to modify the behavior of the first case above, the, changing the second is a light touch that does should not change the current, expected behavior. 

### Issues Resolved
None

### Check List

- [No] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
I've been so far unsuccessful at setting up testing for community cookbooks outside of my own lab. Working on it still.
- [N/A] New functionality includes testing.
- [N/A] New functionality has been documented in the README if applicable
- [Yes] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>