### PR TITLE
Fix exec_command property to be overridable as node attribute

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,6 +22,7 @@ chef_client_updater 'update chef-client' do
   version node['chef_client_updater']['version']
   prevent_downgrade node['chef_client_updater']['prevent_downgrade']
   post_install_action node['chef_client_updater']['post_install_action']
+  exec_command node['chef_client_updater']['exec_command'] if node['chef_client_updater']['exec_command']
   download_url_override node['chef_client_updater']['download_url_override'] if node['chef_client_updater']['download_url_override']
   checksum node['chef_client_updater']['checksum'] if node['chef_client_updater']['checksum']
   upgrade_delay node['chef_client_updater']['upgrade_delay'] unless node['chef_client_updater']['upgrade_delay'].nil?


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

### Description
To utilize the command with `post_install_action` property, we should make `exec_command` value from `kill` to `exec`. But the value is not adjustable with override attribute.
To fix this, it should have selective value with attribute on the resource.

### Issues Resolved
#246

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>