### PR TITLE
Switch unified_mode to resource not provider

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -28,8 +28,6 @@ use_inline_resources # cookstyle: disable ChefDeprecations/UseInlineResourcesDef
 
 provides :chef_client_updater if respond_to?(:provides) # cookstyle: disable ChefModernize/RespondToProvides
 
-unified_mode true if respond_to?(:unified_mode)
-
 def load_mixlib_install
   gem 'mixlib-install', '~> 3.12'
   require 'mixlib/install'

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -24,6 +24,8 @@
 
 provides :chef_client_updater
 
+unified_mode true if respond_to?(:unified_mode)
+
 actions [:update]
 default_action :update
 


### PR DESCRIPTION
`unified_mode` needs to be enabled for the resource, not provider. This correctly fixes the deprecation error in Chef 17.

Works as expected with OSL's base cookbook

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>