### PR TITLE
adding fix for cinc upgrade

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -29,12 +29,12 @@ use_inline_resources # cookstyle: disable ChefDeprecations/UseInlineResourcesDef
 provides :chef_client_updater if respond_to?(:provides) # cookstyle: disable ChefModernize/RespondToProvides
 
 def load_mixlib_install
-  gem 'mixlib-install', '~> 3.12'
+  gem 'mixlib-install', '>= 3.12.23'
   require 'mixlib/install'
 rescue LoadError
   Chef::Log.info('mixlib-install gem not found. Installing now')
   chef_gem 'mixlib-install' do
-    version '~> 3.12'
+    version '>= 3.12.23'
     compile_time true if respond_to?(:compile_time) # cookstyle: disable ChefModernize/RespondToCompileTime
     if new_resource.rubygems_url
       clear_sources true if respond_to?(:clear_sources)


### PR DESCRIPTION
There is support available for the cinc in the chef_client_updater cookbook but for mixlib-install it was introduced with https://github.com/chef/mixlib-install/pull/340. The mixlib-install release is 3.12.23, which contains the changes to include cinc in the list of product matrix.

After updating found that the upgrade is still failing which is because chef_client_updater still contains the old release at https://github.com/chef-cookbooks/chef_client_updater/blob/main/providers/default.rb#L32-L37.
So mixlib-install version should be either equal or greater than 3.12.23.