### PR TITLE
Support upgrading of CINC Client

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -241,6 +241,8 @@ end
 def legacy_conf_dir_name
   if defined?(::ChefUtils::Dist::Org::LEGACY_CONF_DIR)
     ::ChefUtils::Dist::Org::LEGACY_CONF_DIR
+  elsif new_resource.product_name == 'cinc'
+    'cinc-project'
   else
     'opscode'
   end


### PR DESCRIPTION
### Description

The directory name is incorrect when upgrading CINC. This change fixes the path.

This change is coupled with https://github.com/chef/mixlib-install/pull/389.

### Related Issues
https://github.com/chef-cookbooks/chef_client_updater/issues/228
https://github.com/chef/mixlib-install/issues/339
https://github.com/chef-cookbooks/chef_client_updater/issues/249

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>