### PR TITLE
CHEF-30601 Update and standardize copyright notices to Progress Software Corporation - copyright_update

### DIFF
--- a/COPYRIGHT.md
+++ b/COPYRIGHT.md
@@ -1,0 +1,1 @@
+Copyright (c) 2017-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.

--- a/README.md
+++ b/README.md
@@ -270,8 +270,6 @@ While this cookbook supports running on Chef Infra Client versions back to 11/12
 ## License
 
 ```text
-Copyright:: 2016-2020, Chef Software, Inc
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -284,3 +282,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
+
+# Copyright
+See [COPYRIGHT.md](./COPYRIGHT.md).

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook:: chef_client_updater
 # Attributes:: default
 #
-# Copyright:: 2016-2020, Chef Software Inc.
+# Copyright:: Copyright (c) 2017-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -3,7 +3,7 @@
 # Resource:: updater
 #
 # Copyright:: 2016-2018, Will Jordan
-# Copyright:: 2016-2020, Chef Software Inc.
+# Copyright:: Copyright (c) 2017-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -3,7 +3,7 @@
 # Cookbook:: chef_client_updater
 # Recipe:: default
 #
-# Copyright:: 2016-2020, Chef Software, Inc.
+# Copyright:: Copyright (c) 2017-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -3,7 +3,7 @@
 # Resource:: updater
 #
 # Copyright:: 2016-2018, Will Jordan
-# Copyright:: 2016-2020, Chef Software Inc.
+# Copyright:: Copyright (c) 2017-2026 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is an automated message using the copyright-automator tool.

This PR updates copyright notices from Chef Software and Opscode to Progress Software Corporation as part of the repository standardization effort.

## Automated Changes

- Updated Opscode, Chef, and Progress copyright notices to use Progress Software Corporation current language
- Applied year range: 2017-2026 reflecting our understanding of repo-specific activity
- Preserved original formatting and comment styles

## Manual Changes Required

⚠️ This PR requires manual intervention for the following files:

- `COPYRIGHT.md:1` - adjust-copyright-file
- `README.md:1` - adjust-readme
- `README.md:273` - adjust-readme

Please review these locations and make appropriate manual edits.

## No Other Changes Intended

- No change to Author, Contributor, or Maintainer information
- No change to non-PSC copyright holders
