### PR TITLE
Making windows installs more resilient

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@3.0.1
       - name: Run unit tests
+        env:
+          CHEF_LICENSE: accept-no-persist
         run: chef exec rspec spec/ --format documentation
 
   yamllint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,16 @@ jobs:
       - name: Cook Style
         run: cookstyle
 
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Install Chef
+        uses: actionshub/chef-install@3.0.1
+      - name: Run unit tests
+        run: chef exec rspec spec/ --format documentation
+
   yamllint:
     runs-on: ubuntu-latest
     steps:

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,28 @@
+require 'rake'
+
+# Run Ruby unit tests via Chef Workstation's bundled RSpec.
+# Mirrors the 'unit' job in .github/workflows/lint.yml.
+desc 'Run Ruby unit tests (spec/)'
+task 'spec:unit' do
+  sh({ 'CHEF_LICENSE' => 'accept-no-persist' }, 'chef exec rspec spec/ --format documentation')
+end
+
+# Run Pester tests for Windows-specific PowerShell behaviour.
+# These tests verify the $LASTEXITCODE guard logic in execute_install_script
+# (providers/default.rb) which cannot be exercised from RSpec/ChefSpec.
+#
+# Requires:  Windows + Pester v5 (built into Windows 10+)
+# Update:    Install-Module -Name Pester -Force -SkipPublisherCheck
+desc 'Run Windows Pester tests (spec/windows/)'
+task 'spec:windows' do
+  unless Gem.win_platform?
+    puts 'spec:windows skipped — Pester tests only run on Windows'
+    next
+  end
+  sh 'powershell -NonInteractive -Command "Invoke-Pester spec/windows/ -Output Detailed; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }"'
+end
+
+desc 'Run all tests (spec:unit + spec:windows on Windows, spec:unit only on non-Windows)'
+task spec: Gem.win_platform? ? %w(spec:unit spec:windows) : %w(spec:unit)
+
+task default: :spec

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -79,7 +79,7 @@ suites:
       - recipe[test::license_id]
     verifier:
       inspec_tests:
-        - path: ./test/integration/default/
+        - path: ./test/integration/license_id/
     attributes:
       chef_client_updater:
         license_id: 'free-79df705d-b685-419a-8b68-88401f74ff72-3999'

--- a/libraries/chef_client_updater_helper.rb
+++ b/libraries/chef_client_updater_helper.rb
@@ -71,4 +71,30 @@ module ChefClientUpdaterHelper
     Chef::Log.warn("Package availability check failed, skipping upgrade: #{e.message}")
     false
   end
+
+  # The version we WANT TO INSTALL. If the user specifies a version in X.Y.Z format
+  # we use that without looking it up — UNLESS license_id is set, in which case the
+  # Trial API silently overrides any specific version to 'latest'. In that case we must
+  # resolve through artifact_info so desired_version reflects what will actually be
+  # installed (preventing an infinite update loop on subsequent runs).
+  # If :latest or a non-X.Y.Z format version, we look it up with mixlib-install.
+  # @return Mixlib::Versioning::Format::PartialSemVer
+  def desired_version
+    load_mixlib_versioning
+    if new_resource.version.to_sym == :latest
+      version = Mixlib::Versioning.parse(mixlib_install.available_versions.last)
+      Chef::Log.debug("User specified version of :latest. Looking up using mixlib-install. Value maps to #{version}.")
+    elsif new_resource.download_url_override
+      version = Mixlib::Versioning.parse(new_resource.version)
+      Chef::Log.debug("download_url_override specified. Using specified version of #{version}")
+    elsif new_resource.version.split('.').count == 3 && !new_resource.license_id
+      Chef::Log.debug("User specified version of #{new_resource.version}. No need check this against Chef servers.")
+      version = Mixlib::Versioning.parse(new_resource.version)
+    else
+      artifact = Array(mixlib_install.artifact_info).first
+      version = Mixlib::Versioning.parse(artifact.version)
+      Chef::Log.debug("User specified version of #{new_resource.version}. Looking up using mixlib-install. Value maps to #{version}.")
+    end
+    version
+  end
 end

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -128,31 +128,6 @@ def current_version
   end
 end
 
-# the version we WANT TO INSTALL. If the user specifies a version in X.Y.X format
-# we use that without looking it up. If :latest or a non-X.Y.Z format version we
-# look it up with mixlib-install to determine the latest version matching the request.
-# When license_id is set we always resolve via the API because the Trial API only
-# supports 'latest' and silently overrides any specific version — skipping the lookup
-# would cause update_necessary? to return true on every run once the latest is installed.
-# @return Mixlib::Versioning::Format::PartialSemVer
-def desired_version
-  if new_resource.version.to_sym == :latest # we need to find what :latest really means
-    version = Mixlib::Versioning.parse(mixlib_install.available_versions.last)
-    Chef::Log.debug("User specified version of :latest. Looking up using mixlib-install. Value maps to #{version}.")
-  elsif new_resource.download_url_override # probably in an air-gapped environment.
-    version = Mixlib::Versioning.parse(new_resource.version)
-    Chef::Log.debug("download_url_override specified. Using specified version of #{version}")
-  elsif new_resource.version.split('.').count == 3 && !new_resource.license_id # X.Y.Z version format given, no API override possible
-    Chef::Log.debug("User specified version of #{new_resource.version}. No need check this against Chef servers.")
-    version = Mixlib::Versioning.parse(new_resource.version)
-  else # lookup their version to find the actual X.Y.Z version the API will provide
-    artifact = Array(mixlib_install.artifact_info).first
-    version = Mixlib::Versioning.parse(artifact.version)
-    Chef::Log.debug("User specified version of #{new_resource.version}. Looking up using mixlib-install. Value maps to #{version}.")
-  end
-  version
-end
-
 # why wouldn't we use the built in update_available? method in mixlib-install?
 # well that would use current_version from mixlib-install and it has no
 # concept of preventing downgrades

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -614,7 +614,19 @@ def execute_install_script(install_script)
 
           Write-Output "Running product install script..."
           try {
+            # Reset $LASTEXITCODE to $null before invoking the install script so that any
+            # non-zero exit code left behind by #{uninstall_if_necessary} (e.g. msiexec /x)
+            # does not produce a false positive on the check below.
+            $LASTEXITCODE = $null
             #{install_script}
+            # PowerShell's try/catch only catches *terminating* errors. External programs
+            # such as msiexec.exe signal failure via a non-zero exit code, not by throwing
+            # an exception, so a failed install would otherwise silently fall through and
+            # leave the node in an indeterminate state. Explicitly convert a non-zero exit
+            # code into a terminating error so the catch block fires and the rollback runs.
+            if ($LASTEXITCODE -ne $null -and $LASTEXITCODE -ne 0) {
+              throw "Install script exited with non-zero exit code: $LASTEXITCODE"
+            }
           }
           catch {
             Write-Output "An error occurred while trying to install product"

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -130,7 +130,10 @@ end
 
 # the version we WANT TO INSTALL. If the user specifies a version in X.Y.X format
 # we use that without looking it up. If :latest or a non-X.Y.Z format version we
-# look it up with mixlib-install to determine the latest version matching the request
+# look it up with mixlib-install to determine the latest version matching the request.
+# When license_id is set we always resolve via the API because the Trial API only
+# supports 'latest' and silently overrides any specific version — skipping the lookup
+# would cause update_necessary? to return true on every run once the latest is installed.
 # @return Mixlib::Versioning::Format::PartialSemVer
 def desired_version
   if new_resource.version.to_sym == :latest # we need to find what :latest really means
@@ -139,12 +142,13 @@ def desired_version
   elsif new_resource.download_url_override # probably in an air-gapped environment.
     version = Mixlib::Versioning.parse(new_resource.version)
     Chef::Log.debug("download_url_override specified. Using specified version of #{version}")
-  elsif new_resource.version.split('.').count == 3 # X.Y.Z version format given
+  elsif new_resource.version.split('.').count == 3 && !new_resource.license_id # X.Y.Z version format given, no API override possible
     Chef::Log.debug("User specified version of #{new_resource.version}. No need check this against Chef servers.")
     version = Mixlib::Versioning.parse(new_resource.version)
-  else # lookup their shortened version to find the X.Y.Z version
-    version = Mixlib::Versioning.parse(Array(mixlib_install.artifact_info).first.version)
-    Chef::Log.debug("User specified version of #{new_resource.version}. Looking up using mixlib-install as this is not X.Y.Z format. Value maps to #{version}.")
+  else # lookup their version to find the actual X.Y.Z version the API will provide
+    artifact = Array(mixlib_install.artifact_info).first
+    version = Mixlib::Versioning.parse(artifact.version)
+    Chef::Log.debug("User specified version of #{new_resource.version}. Looking up using mixlib-install. Value maps to #{version}.")
   end
   version
 end

--- a/spec/unit/libraries/chef_client_updater_helper_spec.rb
+++ b/spec/unit/libraries/chef_client_updater_helper_spec.rb
@@ -167,4 +167,91 @@ describe ChefClientUpdaterHelper do
       end
     end
   end
+
+  describe '#desired_version' do
+    let(:mixlib_instance) { double('Mixlib::Install') }
+    let(:versioning) { double('Mixlib::Versioning') }
+
+    before do
+      allow(provider).to receive(:mixlib_install).and_return(mixlib_instance)
+      allow(provider).to receive(:load_mixlib_versioning)
+      stub_const('Mixlib::Versioning', versioning)
+      allow(versioning).to receive(:parse) { |v| v }
+      allow(Chef::Log).to receive(:debug)
+    end
+
+    context 'when version is :latest' do
+      before { allow(resource).to receive(:version).and_return('latest') }
+
+      it 'resolves to the last value from available_versions' do
+        allow(mixlib_instance).to receive(:available_versions).and_return(%w[18.10.17 18.11.11])
+        expect(provider.desired_version).to eq('18.11.11')
+      end
+
+      it 'does not call artifact_info' do
+        allow(mixlib_instance).to receive(:available_versions).and_return(%w[18.11.11])
+        expect(mixlib_instance).not_to receive(:artifact_info)
+        provider.desired_version
+      end
+    end
+
+    context 'when version is X.Y.Z and license_id is nil' do
+      before do
+        allow(resource).to receive(:version).and_return('18.10.17')
+        allow(resource).to receive(:download_url_override).and_return(nil)
+        allow(resource).to receive(:license_id).and_return(nil)
+      end
+
+      it 'returns the requested version without calling the API' do
+        expect(mixlib_instance).not_to receive(:artifact_info)
+        expect(provider.desired_version).to eq('18.10.17')
+      end
+    end
+
+    context 'when version is X.Y.Z and license_id is set (Trial API scenario)' do
+      let(:artifact) { double('artifact', version: '18.11.11') }
+
+      before do
+        allow(resource).to receive(:version).and_return('18.10.17')
+        allow(resource).to receive(:download_url_override).and_return(nil)
+        allow(resource).to receive(:license_id).and_return('free-trial-key')
+        allow(mixlib_instance).to receive(:artifact_info).and_return([artifact])
+      end
+
+      it 'resolves through artifact_info to reflect what the Trial API will actually install' do
+        expect(provider.desired_version).to eq('18.11.11')
+      end
+
+      it 'does not return the originally-requested version' do
+        expect(provider.desired_version).not_to eq('18.10.17')
+      end
+    end
+
+    context 'when version is a short format (not X.Y.Z) without license_id' do
+      let(:artifact) { double('artifact', version: '18.11.11') }
+
+      before do
+        allow(resource).to receive(:version).and_return('18')
+        allow(resource).to receive(:download_url_override).and_return(nil)
+        allow(resource).to receive(:license_id).and_return(nil)
+        allow(mixlib_instance).to receive(:artifact_info).and_return([artifact])
+      end
+
+      it 'resolves through artifact_info to find the full X.Y.Z version' do
+        expect(provider.desired_version).to eq('18.11.11')
+      end
+    end
+
+    context 'when download_url_override is set' do
+      before do
+        allow(resource).to receive(:version).and_return('18.10.17')
+        allow(resource).to receive(:download_url_override).and_return('https://example.com/chef.rpm')
+      end
+
+      it 'uses the specified version directly without calling the API' do
+        expect(mixlib_instance).not_to receive(:artifact_info)
+        expect(provider.desired_version).to eq('18.10.17')
+      end
+    end
+  end
 end

--- a/spec/unit/libraries/chef_client_updater_helper_spec.rb
+++ b/spec/unit/libraries/chef_client_updater_helper_spec.rb
@@ -184,12 +184,12 @@ describe ChefClientUpdaterHelper do
       before { allow(resource).to receive(:version).and_return('latest') }
 
       it 'resolves to the last value from available_versions' do
-        allow(mixlib_instance).to receive(:available_versions).and_return(%w[18.10.17 18.11.11])
+        allow(mixlib_instance).to receive(:available_versions).and_return(%w(18.10.17 18.11.11))
         expect(provider.desired_version).to eq('18.11.11')
       end
 
       it 'does not call artifact_info' do
-        allow(mixlib_instance).to receive(:available_versions).and_return(%w[18.11.11])
+        allow(mixlib_instance).to receive(:available_versions).and_return(%w(18.11.11))
         expect(mixlib_instance).not_to receive(:artifact_info)
         provider.desired_version
       end

--- a/spec/unit/providers/default_spec.rb
+++ b/spec/unit/providers/default_spec.rb
@@ -1,5 +1,12 @@
 require 'spec_helper'
 
+# NOTE: The Windows upgrade path in execute_install_script (the powershell_script resource
+# rendered via .run_action(:run)) cannot be meaningfully unit tested here because ChefSpec
+# does not intercept immediate run_action calls. Behavioral coverage for the Windows
+# $LASTEXITCODE exit-code check and rollback path requires a Windows Test Kitchen suite
+# that converges with a mock install script that exits non-zero and then asserts the
+# backup directory was restored. See kitchen.yml for the existing Linux suites.
+
 describe 'chef_client_updater provider' do
   platform 'ubuntu', '22.04'
 

--- a/spec/unit/providers/default_spec.rb
+++ b/spec/unit/providers/default_spec.rb
@@ -10,34 +10,33 @@ require 'spec_helper'
 describe 'chef_client_updater provider' do
   platform 'ubuntu', '22.04'
 
-  let(:chef_run) do
-    ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '22.04', step_into: ['chef_client_updater']) do |node|
-      node.normal['chef_client_updater']['product_name'] = product_name
-      node.normal['chef_client_updater']['version'] = '18.0.0'
-      node.normal['chef_client_updater']['license_id'] = 'test-license-key'
-    end
-  end
-
   context 'when product_name is chef-ice' do
-    let(:product_name) { 'chef-ice' }
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '22.04', step_into: ['chef_client_updater']) do |node|
+        node.normal['chef_client_updater']['product_name'] = 'chef-ice'
+        node.normal['chef_client_updater']['version'] = '18.0.0'
+      end
+    end
 
     it 'raises an error about unsupported product' do
-      chef_run.converge('chef_client_updater::default')
-      expect { chef_run }.to raise_error(RuntimeError, /Unsupported product: chef-ice/)
+      expect { chef_run.converge('chef_client_updater::default') }.to raise_error(RuntimeError, /Unsupported product: chef-ice/)
     end
 
     it 'includes error message stating cookbook only supports Chef 18 and below' do
-      chef_run.converge('chef_client_updater::default')
-      expect { chef_run }.to raise_error(RuntimeError, /only supports omnibus versions of Chef Infra Client 18 and below/)
+      expect { chef_run.converge('chef_client_updater::default') }.to raise_error(RuntimeError, /only supports omnibus versions of Chef Infra Client 18 and below/)
     end
   end
 
+  # For 'does not raise' contexts we set matching current/desired versions (both 18.0.0)
+  # and populate node.automatic['chef_packages'] so current_version works without ohai.
+  # With no license_id, desired_version uses the X.Y.Z fast path (no API call needed).
   context 'when product_name is chef' do
-    let(:product_name) { 'chef' }
-
-    before do
-      # Mock the version check to avoid actual upgrade logic
-      allow_any_instance_of(Object).to receive(:update_necessary?).and_return(false)
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '22.04', step_into: ['chef_client_updater']) do |node|
+        node.normal['chef_client_updater']['product_name'] = 'chef'
+        node.normal['chef_client_updater']['version'] = '18.0.0'
+        node.automatic['chef_packages'] = { 'chef' => { 'version' => '18.0.0' } }
+      end
     end
 
     it 'does not raise an error' do
@@ -46,11 +45,11 @@ describe 'chef_client_updater provider' do
   end
 
   context 'when product_name is not set (defaults to chef)' do
-    let(:product_name) { nil }
-
-    before do
-      # Mock the version check to avoid actual upgrade logic
-      allow_any_instance_of(Object).to receive(:update_necessary?).and_return(false)
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '22.04', step_into: ['chef_client_updater']) do |node|
+        node.normal['chef_client_updater']['version'] = '18.0.0'
+        node.automatic['chef_packages'] = { 'chef' => { 'version' => '18.0.0' } }
+      end
     end
 
     it 'does not raise an error' do

--- a/spec/unit/resources/default_spec.rb
+++ b/spec/unit/resources/default_spec.rb
@@ -36,8 +36,10 @@ describe 'chef_client_updater resource' do
   describe 'license_id parameter' do
     # Set attributes in the runner block (not in before) so they are guaranteed to be
     # present when the recipe is compiled during converge.
-    # Stub update_necessary? via Chef::Provider (the LWRP base class) to avoid needing
-    # mixlib-install network calls when license_id is set.
+    # Stub mixlib_install at the ChefClientUpdaterHelper level (where desired_version lives)
+    # to return a fake artifact matching the current version, so update_necessary? returns
+    # false without making any real HTTP calls. allow_any_instance_of(Chef::Provider) cannot
+    # stub methods defined on the LWRP subclass itself.
     context 'when license_id is provided' do
       let(:chef_run) do
         ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '22.04', step_into: ['chef_client_updater']) do |node|
@@ -48,7 +50,11 @@ describe 'chef_client_updater resource' do
       end
 
       before do
-        allow_any_instance_of(Chef::Provider).to receive(:update_necessary?).and_return(false)
+        fake_artifact = double('artifact', version: '18.0.0', url: 'https://example.com/chef.rpm')
+        fake_mixlib = double('Mixlib::Install', artifact_info: [fake_artifact])
+        allow_any_instance_of(ChefClientUpdaterHelper).to receive(:load_mixlib_install)
+        allow_any_instance_of(ChefClientUpdaterHelper).to receive(:load_mixlib_versioning)
+        allow_any_instance_of(ChefClientUpdaterHelper).to receive(:mixlib_install).and_return(fake_mixlib)
       end
 
       it 'does not log a warning about missing license_id' do
@@ -63,10 +69,6 @@ describe 'chef_client_updater resource' do
           node.normal['chef_client_updater']['version'] = '18.0.0'
           node.automatic['chef_packages'] = { 'chef' => { 'version' => '18.0.0' } }
         end
-      end
-
-      before do
-        allow_any_instance_of(Chef::Provider).to receive(:update_necessary?).and_return(false)
       end
 
       it 'logs a warning about missing license_id' do

--- a/spec/unit/resources/default_spec.rb
+++ b/spec/unit/resources/default_spec.rb
@@ -4,56 +4,74 @@ describe 'chef_client_updater resource' do
   platform 'ubuntu', '22.04'
 
   describe 'chef-ice product validation' do
-    let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '22.04', step_into: ['chef_client_updater']) do |node|
-        node.normal['chef_client_updater']['license_id'] = 'test-license-key'
-      end
-    end
-
+    # Use chef_client_updater::default (reads product_name from node attribute).
+    # test::chef_ice does not exist; the default recipe is the canonical entry point.
     context 'when using chef-ice as product_name' do
+      let(:chef_run) do
+        ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '22.04', step_into: ['chef_client_updater']) do |node|
+          node.normal['chef_client_updater']['product_name'] = 'chef-ice'
+          node.normal['chef_client_updater']['version'] = '18.0.0'
+        end
+      end
+
       it 'raises an error about unsupported product' do
-        chef_run.converge('test::chef_ice')
-        expect { chef_run }.to raise_error(RuntimeError, /Unsupported product: chef-ice/)
+        expect { chef_run.converge('chef_client_updater::default') }.to raise_error(RuntimeError, /Unsupported product: chef-ice/)
       end
     end
 
     context 'when using chef as product_name' do
-      before do
-        # Mock the version check to avoid actual upgrade logic
-        allow_any_instance_of(Object).to receive(:update_necessary?).and_return(false)
+      let(:chef_run) do
+        ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '22.04', step_into: ['chef_client_updater']) do |node|
+          node.normal['chef_client_updater']['version'] = '18.0.0'
+          node.automatic['chef_packages'] = { 'chef' => { 'version' => '18.0.0' } }
+        end
       end
 
       it 'does not raise an error' do
-        expect { chef_run.converge('test::default') }.not_to raise_error
+        expect { chef_run.converge('chef_client_updater::default') }.not_to raise_error
       end
     end
   end
 
   describe 'license_id parameter' do
-    let(:chef_run) do
-      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '22.04', step_into: ['chef_client_updater'])
-    end
-
+    # Set attributes in the runner block (not in before) so they are guaranteed to be
+    # present when the recipe is compiled during converge.
+    # Stub update_necessary? via Chef::Provider (the LWRP base class) to avoid needing
+    # mixlib-install network calls when license_id is set.
     context 'when license_id is provided' do
+      let(:chef_run) do
+        ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '22.04', step_into: ['chef_client_updater']) do |node|
+          node.normal['chef_client_updater']['version'] = '18.0.0'
+          node.normal['chef_client_updater']['license_id'] = 'test-license-123'
+          node.automatic['chef_packages'] = { 'chef' => { 'version' => '18.0.0' } }
+        end
+      end
+
       before do
-        allow_any_instance_of(Object).to receive(:update_necessary?).and_return(false)
-        chef_run.node.default['chef_client_updater']['license_id'] = 'test-license-123'
+        allow_any_instance_of(Chef::Provider).to receive(:update_necessary?).and_return(false)
       end
 
       it 'does not log a warning about missing license_id' do
         expect(Chef::Log).not_to receive(:warn).with(/No license_id specified/)
-        chef_run.converge('test::default')
+        chef_run.converge('chef_client_updater::default')
       end
     end
 
     context 'when license_id is not provided' do
+      let(:chef_run) do
+        ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '22.04', step_into: ['chef_client_updater']) do |node|
+          node.normal['chef_client_updater']['version'] = '18.0.0'
+          node.automatic['chef_packages'] = { 'chef' => { 'version' => '18.0.0' } }
+        end
+      end
+
       before do
-        allow_any_instance_of(Object).to receive(:update_necessary?).and_return(false)
+        allow_any_instance_of(Chef::Provider).to receive(:update_necessary?).and_return(false)
       end
 
       it 'logs a warning about missing license_id' do
         expect(Chef::Log).to receive(:warn).with(/No license_id specified/)
-        chef_run.converge('test::default')
+        chef_run.converge('chef_client_updater::default')
       end
     end
   end

--- a/spec/windows/install_script_guard.Tests.ps1
+++ b/spec/windows/install_script_guard.Tests.ps1
@@ -1,0 +1,236 @@
+#
+# Pester tests for the $LASTEXITCODE exit-code guard pattern used inside the
+# powershell_script resource rendered by execute_install_script
+# (providers/default.rb, ~line 596).
+#
+# WHY THESE TESTS EXIST
+# =====================
+# PowerShell's try/catch only catches *terminating* errors. External programs like
+# msiexec.exe signal failure via a non-zero $LASTEXITCODE, not by throwing. Without
+# the explicit $LASTEXITCODE check added in this PR, a failed install silently falls
+# through, leaving the node with no /opt/chef directory and no backup — an
+# indeterminate state that causes random subsequent Chef failures on Windows.
+#
+# Additionally, a prior msiexec /x (uninstall step) can leave a non-zero
+# $LASTEXITCODE that would cause a false positive failure on the install step unless
+# $LASTEXITCODE is explicitly reset to $null immediately before the install script runs.
+#
+# These tests verify both behaviours in pure PowerShell, without needing Chef or a VM.
+#
+# HOW TO RUN (requires Pester v5, built into Windows 10+)
+# ========================================================
+#   Invoke-Pester .\spec\windows\install_script_guard.Tests.ps1 -Output Detailed
+#
+#   If Pester is outdated, update it first:
+#   Install-Module -Name Pester -Force -SkipPublisherCheck
+#
+# WHAT IS TESTED vs. NOT TESTED
+# ==============================
+# Tested:   the try/catch/$LASTEXITCODE guard logic (pure PowerShell semantics)
+# Tested:   filesystem rollback (Move-Item backup -> install dir on failure)
+# Tested:   stale $LASTEXITCODE from a prior command causes no false-positive failure
+# NOT tested: the full Chef converge, WinRM transport, scheduled task creation,
+#             or anything requiring a real Windows VM (use kitchen.yml for those).
+
+BeforeAll {
+    # Helper that mirrors the try/catch/$LASTEXITCODE guard block from providers/default.rb.
+    # This is a test double of the PowerShell logic Chef interpolates into the upgrade
+    # script heredoc — it is NOT imported production code.
+    #
+    # NOTE: do NOT use this helper for the 'stale $LASTEXITCODE' test — see that context
+    # for why it must run the pattern in the caller's scope via dot-sourcing.
+    function Invoke-WithExitCodeGuard {
+        param(
+            [ScriptBlock] $InstallScript,
+            [string]      $BackupDir,
+            [string]      $InstallDir
+        )
+        try {
+            # Dot-source the install scriptblock so it runs in the current (function)
+            # scope. Using & creates a child scope where $LASTEXITCODE is updated but
+            # that child scope is discarded on return, leaving this scope's $LASTEXITCODE
+            # unchanged.
+            # NOTE: we do NOT set $LASTEXITCODE = $null here. Inside a function, that
+            # assignment creates a local variable that shadows the automatic $LASTEXITCODE.
+            # External processes then update the automatic variable at a higher scope while
+            # the check below still reads the local $null shadow — causing a false negative.
+            # The $LASTEXITCODE = $null reset that exists in providers/default.rb works
+            # because it runs at top-level script scope with no shadowing. That behaviour
+            # is tested separately in the 'stale $LASTEXITCODE' context below.
+            . $InstallScript
+            # PowerShell try/catch only catches *terminating* errors. External programs
+            # signal failure via a non-zero exit code, not by throwing, so a failed install
+            # would otherwise silently fall through. Explicitly convert a non-zero exit code
+            # into a terminating error so the catch block fires and rollback runs.
+            if ($LASTEXITCODE -ne $null -and $LASTEXITCODE -ne 0) {
+                throw "Install script exited with non-zero exit code: $LASTEXITCODE"
+            }
+        }
+        catch {
+            if (Test-Path $BackupDir) {
+                Move-Item -Path $BackupDir -Destination $InstallDir
+            }
+            throw
+        }
+    }
+}
+
+Describe 'execute_install_script $LASTEXITCODE guard (providers/default.rb)' {
+
+    BeforeAll {
+        $script:testRoot = Join-Path $env:TEMP "chef_pester_$(Get-Random)"
+        New-Item -Path $script:testRoot -ItemType Directory | Out-Null
+    }
+
+    AfterAll {
+        Remove-Item -Path $script:testRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    BeforeEach {
+        $script:backupDir  = Join-Path $script:testRoot "chef.bak"
+        $script:installDir = Join-Path $script:testRoot "chef"
+        New-Item -Path $script:backupDir -ItemType Directory | Out-Null
+        Set-Content -Path (Join-Path $script:backupDir 'sentinel.txt') -Value 'original'
+    }
+
+    AfterEach {
+        Remove-Item -Path $script:backupDir  -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-Item -Path $script:installDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    Context 'when the install script succeeds (exits 0)' {
+        It 'completes without error' {
+            { Invoke-WithExitCodeGuard `
+                -InstallScript { cmd.exe /c "exit 0" } `
+                -BackupDir  $script:backupDir `
+                -InstallDir $script:installDir
+            } | Should -Not -Throw
+        }
+
+        It 'leaves the backup directory untouched — no rollback' {
+            Invoke-WithExitCodeGuard `
+                -InstallScript { cmd.exe /c "exit 0" } `
+                -BackupDir  $script:backupDir `
+                -InstallDir $script:installDir
+
+            Test-Path $script:backupDir  | Should -BeTrue
+            Test-Path $script:installDir | Should -BeFalse
+        }
+    }
+
+    Context 'when the install script fails via a non-zero exit code' {
+        It 'throws an error containing the failing exit code' {
+            { Invoke-WithExitCodeGuard `
+                -InstallScript { cmd.exe /c "exit 2" } `
+                -BackupDir  $script:backupDir `
+                -InstallDir $script:installDir
+            } | Should -Throw -ExpectedMessage '*non-zero exit code: 2*'
+        }
+
+        It 'reports the exact exit code, not a hardcoded value' {
+            { Invoke-WithExitCodeGuard `
+                -InstallScript { cmd.exe /c "exit 99" } `
+                -BackupDir  $script:backupDir `
+                -InstallDir $script:installDir
+            } | Should -Throw -ExpectedMessage '*99*'
+        }
+
+        It 'moves the backup directory back to the install path (rollback)' {
+            { Invoke-WithExitCodeGuard `
+                -InstallScript { cmd.exe /c "exit 2" } `
+                -BackupDir  $script:backupDir `
+                -InstallDir $script:installDir
+            } | Should -Throw
+
+            Test-Path $script:backupDir  | Should -BeFalse  # backup was moved
+            Test-Path $script:installDir | Should -BeTrue   # restored to install path
+            Get-Content (Join-Path $script:installDir 'sentinel.txt') | Should -Be 'original'
+        }
+    }
+
+    Context 'when the install script throws a terminating error (not an exit code)' {
+        It 'also triggers rollback' {
+            { Invoke-WithExitCodeGuard `
+                -InstallScript { throw 'simulated fatal installer error' } `
+                -BackupDir  $script:backupDir `
+                -InstallDir $script:installDir
+            } | Should -Throw
+
+            Test-Path $script:backupDir  | Should -BeFalse
+            Test-Path $script:installDir | Should -BeTrue
+            Get-Content (Join-Path $script:installDir 'sentinel.txt') | Should -Be 'original'
+        }
+    }
+
+    Context 'stale $LASTEXITCODE from a prior command (e.g. msiexec /x uninstall step)' {
+        # IMPORTANT: This test does NOT use the Invoke-WithExitCodeGuard helper.
+        # If it did, the function's own scope would shadow the outer $LASTEXITCODE = 1,
+        # making the test pass regardless of whether the "$LASTEXITCODE = $null" reset
+        # line exists in the guard. Instead, we dot-source the pattern directly into the
+        # current scope (". { ... }"), which is how the code actually runs in the
+        # generated upgrade script — as flat, top-level PowerShell statements.
+        It 'does not cause a false-positive failure when the install script itself exits 0' {
+            # Step 1: simulate contamination left by a prior command (e.g. msiexec /x)
+            cmd.exe /c "exit 1"
+            $LASTEXITCODE | Should -Be 1  # confirm the contamination is present
+
+            # Step 2: run the guard pattern inline in this scope — the "$LASTEXITCODE = $null"
+            # reset must clear the stale value, otherwise exit 1 triggers a spurious rollback.
+            $rolledBack = $false
+            . {
+                try {
+                    $LASTEXITCODE = $null
+                    # Use a pure PowerShell cmdlet (no external process) so that
+                    # $LASTEXITCODE is not updated by the install script itself.
+                    # This is the scenario the reset is guarding against: a prior
+                    # step (e.g. msiexec /x) left a stale non-zero $LASTEXITCODE,
+                    # and the install logic runs only PowerShell cmdlets.
+                    Write-Output 'Install script completed'  # no external process
+                    if ($LASTEXITCODE -ne $null -and $LASTEXITCODE -ne 0) {
+                        throw "Install script exited with non-zero exit code: $LASTEXITCODE"
+                    }
+                }
+                catch {
+                    $rolledBack = $true
+                    if (Test-Path $script:backupDir) {
+                        Move-Item -Path $script:backupDir -Destination $script:installDir
+                    }
+                }
+            }
+
+            $rolledBack | Should -BeFalse  # no rollback should have occurred
+            Test-Path $script:backupDir  | Should -BeTrue
+            Test-Path $script:installDir | Should -BeFalse
+        }
+
+        It 'confirms the bug: without the reset, stale exit code 1 causes a false-positive rollback' {
+            # This test documents the original buggy behaviour for reference.
+            # It deliberately omits "$LASTEXITCODE = $null" to show the failure mode.
+            cmd.exe /c "exit 1"   # prior command contaminates $LASTEXITCODE
+            $LASTEXITCODE | Should -Be 1
+
+            $rolledBack = $false
+            . {
+                try {
+                    # NO reset here — this is the buggy version.
+                    # The install script uses only PowerShell cmdlets (no external
+                    # process), so $LASTEXITCODE is NOT overwritten by the install.
+                    # This leaves the stale value of 1 from the prior msiexec /x.
+                    Write-Output 'Install script completed'  # no external process
+                    if ($LASTEXITCODE -ne $null -and $LASTEXITCODE -ne 0) {
+                        throw "Install script exited with non-zero exit code: $LASTEXITCODE"
+                    }
+                }
+                catch {
+                    $rolledBack = $true
+                    if (Test-Path $script:backupDir) {
+                        Move-Item -Path $script:backupDir -Destination $script:installDir
+                    }
+                }
+            }
+
+            # The bug: rollback fires even though the install succeeded
+            $rolledBack | Should -BeTrue
+        }
+    }
+}

--- a/test/integration/license_id/default_spec.rb
+++ b/test/integration/license_id/default_spec.rb
@@ -1,0 +1,11 @@
+# The license-id suite uses the Trial API which only supports 'latest', so we cannot
+# assert a specific pinned version. Instead we verify that the chef-client was upgraded
+# beyond the kitchen baseline (18.6.2) and that the embedded gem meets the minimum.
+describe command('chef-client -v') do
+  its('stdout') { should match '^Chef Infra Client: ' }
+  its('stdout') { should_not match '^Chef Infra Client: 18\.6\.2' }
+end
+
+describe command('/opt/chef/embedded/bin/gem -v') do
+  its('stdout') { should cmp >= '2.6.11' }
+end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

### Description
Fix: Windows upgrade rollback never triggered on install script failure

The Windows upgrade path in [`execute_install_script`] wraps the install script call in a PowerShell try/catch block intended to roll back to the backup directory if installation fails. However, PowerShell's try/catch only catches terminating errors — external programs such as msiexec.exe signal failure via a non-zero exit code, which is a non-terminating condition. As a result, a failed installation silently fell through the catch block, the backup was never restored, and the node was left in an indeterminate state with no Chef Infra Client installed.

Changes:

Reset $LASTEXITCODE to $null immediately before invoking the install script. This prevents a stale exit code left by the preceding [`uninstall_if_necessary`] block (which may itself call msiexec /x) from causing a false positive.
After the install script runs, explicitly check $LASTEXITCODE and throw a terminating error if it is non-zero. This ensures the existing catch block fires correctly, the backup directory is moved back to the install path, and the run exits with code 100 as designed.

This mirrors the behaviour of the non-Windows code path, which already checks [`upgrade_command.exitstatus != 0`] and raises on failure.

A comment has also been added to [`default_spec.rb`] noting that this Windows-specific behaviour requires a Windows Test Kitchen suite for full integration coverage, as ChefSpec cannot exercise the [`run_action(:run)`] path.

Version checking to moved to the chef_client_updater_helper.rb for two reasons, both driven by testability:

The LWRP class barrier: Methods defined directly on the old-style LWRP provider (default.rb) live on the auto-generated subclass Chef::Provider::ChefClientUpdater, not on Chef::Provider itself. That means allow_any_instance_of(Chef::Provider) in ChefSpec won't stub them — the stub simply never fires. Moving the method into ChefClientUpdaterHelper (a plain module) means it can be stubbed with allow_any_instance_of(ChefClientUpdaterHelper), which works correctly.

Direct unit testing: Once it's in the helper module, chef_client_updater_helper_spec.rb can test desired_version in isolation — including the new license_id branch and the X.Y.Z fast-path — without spinning up a full ChefSpec runner or making real HTTP calls to mixlib-install's API.

### Issues Resolved
<!--- List any existing issues this PR resolves -->

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>